### PR TITLE
feat(agentMark): generate speech 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .yarn/releases/*
 .yalc
 yalc.lock
+.env

--- a/apps/demo/index.ts
+++ b/apps/demo/index.ts
@@ -1,31 +1,36 @@
 import 'dotenv/config';
 import { openai } from '@ai-sdk/openai';
-import { generateObject, generateText } from 'ai';
+import { generateObject, generateText, experimental_generateSpeech as generateSpeech } from 'ai';
 import PuzzletTypes from './puzzlet1.types';
 import { createAgentMark, FileLoader } from "@puzzlet/agentmark";
 import { VercelAIAdapter, VercelAIModelRegistry } from "@puzzlet/vercel-ai-v4-adapter";
 
 const modelRegistry = new VercelAIModelRegistry();
-const loader = new FileLoader('./fixtures');
+const loader = new FileLoader('./packages/agentmark/test');
 modelRegistry.registerModels(['gpt-4o', 'gpt-4o-mini'], (name: string) => {
   return openai(name);
 });
 
-const adapter = new VercelAIAdapter<PuzzletTypes>(modelRegistry);
+modelRegistry.registerModels(['tts-1-hd', 'tts-1', 'gpt-4o-mini-tts'], (name: string) => (
+  openai.speech(name)
+));
+
+const adapter = new VercelAIAdapter(modelRegistry);
 const agentMark = createAgentMark({
   loader,
   adapter,
 });
 
 async function run () {
-  const prompt = await agentMark.loadObjectPrompt('test/math2.prompt.mdx');
+  const prompt = await agentMark.loadSpeechPrompt('fixtures/speech.prompt.mdx');
   const props = {
     userMessage: "Whats 2 + 3?"
   };
 
   const vercelInput = await prompt.format(props);
-  const result = await generateText(vercelInput);
-  console.log(result.text);
+  const result = await generateSpeech(vercelInput);
+  console.log(result);
+  console.log(result.audio)
 }
 
 run();

--- a/packages/agentmark/src/adapters/default.ts
+++ b/packages/agentmark/src/adapters/default.ts
@@ -28,4 +28,10 @@ export class DefaultAdapter<
   ): ImageConfig {
     return input;
   }
+
+  adaptSpeech(
+    input: any,
+  ): any {
+    return input;
+  }
 }

--- a/packages/agentmark/src/agentmark.ts
+++ b/packages/agentmark/src/agentmark.ts
@@ -1,7 +1,7 @@
 import { Loader, TemplateEngine, Adapter, PromptShape, KeysWithKind } from "./types";
-import { ImageConfigSchema, ObjectConfigSchema, TextConfigSchema } from "./schemas";
+import { ImageConfigSchema, ObjectConfigSchema, TextConfigSchema, SpeechCongfigSchema } from "./schemas";
 import { TemplateDXTemplateEngine } from "./template_engines/templatedx";
-import { ObjectPrompt, ImagePrompt, TextPrompt } from "./prompts";
+import { ObjectPrompt, ImagePrompt, TextPrompt, SpeechPrompt } from "./prompts";
 
 export interface AgentMarkOptions<
   T extends PromptShape<T>,
@@ -79,6 +79,25 @@ export class AgentMark<
       content, this.templateEngine, this.adapter, pathOrPreloaded,
     );
   }
+
+  async loadSpeechPrompt<K extends KeysWithKind<T, 'speech'> & string>(
+    pathOrPreloaded: K,
+    options?: any
+  ) {
+    let content: unknown;
+    
+    if (typeof pathOrPreloaded === 'string' && this.loader) {
+      content = await this.loader.load(pathOrPreloaded, options);
+    } else {
+      content = pathOrPreloaded;
+    }
+    
+    SpeechCongfigSchema.parse(await this.templateEngine.compile(content));
+    return new SpeechPrompt<T, A, K>(
+      content, this.templateEngine, this.adapter, pathOrPreloaded,
+    );
+  }
+
 }
 
 type DictOf<A extends Adapter<any>> = A['__dict'];

--- a/packages/agentmark/src/index.ts
+++ b/packages/agentmark/src/index.ts
@@ -6,11 +6,12 @@ export { TemplateDXTemplateEngine } from './template_engines/templatedx';
 export type { 
   TextConfig,
   ImageConfig,
+  SpeechConfig,
+  ObjectConfig,
   Adapter,
   PromptMetadata,
   ChatMessage,
   AdaptOptions,
-  ObjectConfig,
   PromptShape,
   PromptKey
 } from './types';

--- a/packages/agentmark/src/prompts/index.ts
+++ b/packages/agentmark/src/prompts/index.ts
@@ -8,6 +8,7 @@ import {
   TextConfig,
   PromptShape,
   PromptKey,
+  SpeechConfig,
 } from '../types';
 
 export abstract class BasePrompt<
@@ -115,6 +116,34 @@ export class ImagePrompt<
   ): Promise<ReturnType<A['adaptImage']>> {
     const compiled = await this.compile(props);
     return this.adapter.adaptImage(
+      compiled,
+      options,
+      this.metadata(props),
+    );
+  }
+}
+
+export class SpeechPrompt<
+  T extends PromptShape<T>,
+  A extends Adapter<T>,
+  K extends PromptKey<T>,
+> extends BasePrompt<T, A, K, SpeechConfig> {
+
+  constructor(
+    tpl: unknown,
+    eng: TemplateEngine,
+    ad: A,
+    path: K,
+  ) {
+    super(tpl, eng, ad, path);
+  }
+
+  async format(
+    props: T[K]['input'],
+    options: AdaptOptions = {},
+  ): Promise<ReturnType<A['adaptSpeech']>> {
+    const compiled = await this.compile(props);
+    return this.adapter.adaptSpeech(
       compiled,
       options,
       this.metadata(props),

--- a/packages/agentmark/src/schemas.ts
+++ b/packages/agentmark/src/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const ChatMessageSchema = z.object({
-  role: z.enum(['system', 'user', 'assistant']),
+  role: z.enum(["system", "user", "assistant"]),
   content: z.string(),
 });
 
@@ -19,13 +19,15 @@ export const TextSettingsConfig = z.object({
   stop_sequences: z.array(z.string()).optional(),
   seed: z.number().optional(),
   max_retries: z.number().optional(),
-  tool_choice: z.union([
-    z.enum(['auto', 'none', 'required']),
-    z.object({
-      type: z.literal('tool'),
-      tool_name: z.string()
-    })
-  ]).optional(),
+  tool_choice: z
+    .union([
+      z.enum(["auto", "none", "required"]),
+      z.object({
+        type: z.literal("tool"),
+        tool_name: z.string(),
+      }),
+    ])
+    .optional(),
   tools: z
     .record(
       z.object({
@@ -60,12 +62,29 @@ export type ObjectSettings = z.infer<typeof ObjectSettingsConfig>;
 export const ImageSettingsConfig = z.object({
   model_name: z.string(),
   num_images: z.number().optional(),
-  size: z.string().regex(/^\d+x\d+$/).optional(),
-  aspect_ratio: z.string().regex(/^\d+:\d+$/).optional(),
+  size: z
+    .string()
+    .regex(/^\d+x\d+$/)
+    .optional(),
+  aspect_ratio: z
+    .string()
+    .regex(/^\d+:\d+$/)
+    .optional(),
   seed: z.number().optional(),
 });
 
 export type ImageSettings = z.infer<typeof ImageSettingsConfig>;
+
+export const SpeechSettingsConfig = z.object({
+  model_name: z.string(),
+  text: z.string(),
+  voice: z.string().optional(),
+  outputFormat: z.string().optional(),
+  instructions: z.string().optional(),
+  speed: z.number().optional(),
+});
+
+export type SpeechSettings = z.infer<typeof SpeechSettingsConfig>;
 
 export const TextConfigSchema = z.object({
   name: z.string(),
@@ -90,3 +109,11 @@ export const ImageConfigSchema = z.object({
 });
 
 export type ImageConfig = z.infer<typeof ImageConfigSchema>;
+
+export const SpeechCongfigSchema = z.object({
+  name: z.string(),
+  messages: z.array(ChatMessageSchema),
+  speech_config: SpeechSettingsConfig,
+});
+
+export type SpeechConfig = z.infer<typeof SpeechCongfigSchema>;

--- a/packages/agentmark/src/template_engines/templatedx.ts
+++ b/packages/agentmark/src/template_engines/templatedx.ts
@@ -2,7 +2,15 @@ import { TagPluginRegistry, transform } from "@puzzlet/templatedx";
 import { TagPlugin, PluginContext, getFrontMatter } from "@puzzlet/templatedx";
 import type { Ast } from "@puzzlet/templatedx";
 import type { Node } from "mdast";
-import { TemplateEngine, ChatMessage, JSONObject, ObjectConfig, TextConfig, ImageConfig } from "../types";
+import { 
+  TemplateEngine, 
+  ChatMessage, 
+  JSONObject, 
+  ObjectConfig, 
+  TextConfig, 
+  ImageConfig, 
+  SpeechConfig 
+} from "../types";
 
 type ExtractedField = {
   name: string;
@@ -83,7 +91,7 @@ function getMessages(extractedFields: Array<any>): ChatMessage[] {
 }
 
 export async function getRawConfig<
-  R extends ObjectConfig | ImageConfig | TextConfig
+  R extends ObjectConfig | ImageConfig | TextConfig | SpeechConfig
 >(ast: Ast, props?: JSONObject): Promise<R> {
   const frontMatter: any = getFrontMatter(ast);
   const shared: SharedContext = {};
@@ -97,5 +105,6 @@ export async function getRawConfig<
     ...(frontMatter.image_config && { image_config: frontMatter.image_config }),
     ...(frontMatter.object_config && { object_config: frontMatter.object_config }),
     ...(frontMatter.text_config && { text_config: frontMatter.text_config }),
+    ...(frontMatter.speech_config && { speech_config: frontMatter.speech_config }),
   };
 }

--- a/packages/agentmark/src/types.ts
+++ b/packages/agentmark/src/types.ts
@@ -5,8 +5,9 @@ import {
   TextConfig,
   ObjectConfig,
   ImageConfig,
-  ChatMessage
-} from './schemas';
+  SpeechConfig,
+  ChatMessage,
+} from "./schemas";
 
 export type JSONPrimitive = string | number | boolean | null;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
@@ -20,26 +21,24 @@ export type {
   TextConfig,
   ImageConfig,
   ObjectConfig,
-  ChatMessage
+  SpeechConfig,
+  ChatMessage,
 };
 
 export type PromptShape<T> = { [K in keyof T]: { input: any; output: any } };
 export type PromptDict = PromptShape<any>;
 export type PromptKey<T extends PromptDict> = keyof T & string;
 
-export type PromptKind = 'object' | 'text' | 'image';
+export type PromptKind = "object" | "text" | "image" | "speech";
 export type KindOf<V> = V extends { kind: infer K } ? K : PromptKind;
-export type KeysWithKind<
-  Dict,
-  K extends PromptKind,
-> = {
-  [P in keyof Dict]: K extends KindOf<Dict[P]> ? P : never
+export type KeysWithKind<Dict, K extends PromptKind> = {
+  [P in keyof Dict]: K extends KindOf<Dict[P]> ? P : never;
 }[keyof Dict];
 
 export interface TemplateEngine {
   compile<R = unknown, P extends Record<string, unknown> = JSONObject>(
     template: unknown,
-    props?: P,
+    props?: P
   ): Promise<R>;
 }
 
@@ -54,10 +53,10 @@ export type BaseAdaptOptions = {
     isEnabled: boolean;
     functionId?: string;
     metadata?: Record<string, unknown>;
-  }
+  };
   apiKey?: string;
   baseURL?: string;
-}
+};
 
 export type AdaptOptions = BaseAdaptOptions & { [key: string]: any };
 
@@ -81,6 +80,12 @@ export interface Adapter<T extends PromptShape<T>> {
 
   adaptImage(
     input: ImageConfig,
+    options: AdaptOptions,
+    metadata: PromptMetadata
+  ): any;
+
+  adaptSpeech(
+    input: SpeechConfig,
     options: AdaptOptions,
     metadata: PromptMetadata
   ): any;

--- a/packages/agentmark/test/fixtures/image.prompt.mdx
+++ b/packages/agentmark/test/fixtures/image.prompt.mdx
@@ -3,6 +3,9 @@ name: image
 image_config:
   model_name: test-model
   num_images: 1
+  size: 512x512
+  aspect_ratio: 1:1
+  seed: 12345
 input_schema:
   type: image
   properties:

--- a/packages/agentmark/test/fixtures/speech.prompt.mdx
+++ b/packages/agentmark/test/fixtures/speech.prompt.mdx
@@ -1,0 +1,15 @@
+---
+name: speech
+speech_config:
+  model_name: test-model
+  text: "Generate a speech for the given text."
+  voice: "en-US-Wavenet-D"
+  speed: 1.0
+  output_format: "mp3"
+  instructions: "Please read this text aloud."
+---
+
+<System>
+You are a helpful math tutor.
+</System>
+

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,6 +1,11 @@
 import * as vscode from "vscode";
 import { createAgentMark, TemplateDXTemplateEngine, VercelAdapter } from "@puzzlet/agentmark";
-import { experimental_generateImage as generateImage, streamObject, streamText } from "ai";
+import {
+  experimental_generateImage as generateImage,
+  experimental_generateSpeech as generateSpeech,
+  streamObject,
+  streamText,
+} from "ai";
 import { getFrontMatter, load } from "@puzzlet/templatedx";
 import { modelConfig, modelRegistry, modelProviderMap } from "./modelRegistry";
 import { loadOldFormat } from "./loadOldFormat";
@@ -45,6 +50,9 @@ export function activate(context: vscode.ExtensionContext) {
       } else if (compiledYaml?.text_config) {
         modelConfig = "text_config";
         model = compiledYaml.text_config;
+      } else if (compiledYaml?.speech_config) {
+        modelConfig = "speech_config";
+        model = compiledYaml.speech_config;
       } else {
         return vscode.window.showErrorMessage(
           "No config (image_config, object_config, or text_config) found in the file."
@@ -90,6 +98,17 @@ export function activate(context: vscode.ExtensionContext) {
             break;
           }
         
+          case "speech_config": {
+            const prompt = await agentMark.loadSpeechPrompt(ast);
+            const vercelInput = await prompt.format(props, { apiKey });
+            const speechResult = await generateSpeech(vercelInput);
+            ch.clear();
+            ch.appendLine("RESULT:");
+            ch.appendLine(JSON.stringify(speechResult, null, 2));
+            ch.show();
+            break;
+          }
+
           case "object_config": {
             const prompt = await agentMark.loadObjectPrompt(ast);
             const vercelInput = await prompt.format(props, { apiKey });

--- a/packages/vscode-extension/src/modelRegistry.ts
+++ b/packages/vscode-extension/src/modelRegistry.ts
@@ -3,35 +3,51 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 
 export const modelRegistry = new VercelModelRegistry();
-modelRegistry.registerModels([
-  "gpt-4o",
-  "gpt-4o-mini",
-  "gpt-4-turbo",
-  "gpt-4",
-  "o1-mini",
-  "o1-preview",
-  "gpt-3.5-turbo",
-], (name: string, options) => {
-  const provider = createOpenAI(options); 
-  return provider(name); 
-});
+modelRegistry.registerModels(
+  [
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4-turbo",
+    "gpt-4",
+    "o1-mini",
+    "o1-preview",
+    "gpt-3.5-turbo",
+  ],
+  (name: string, options) => {
+    const provider = createOpenAI(options);
+    return provider(name);
+  }
+);
 
-modelRegistry.registerModels(['dall-e-3', 'dall-e-2'], 
+modelRegistry.registerModels(
+  ["dall-e-3", "dall-e-2"],
   (name: string, options) => {
     const provider = createOpenAI(options);
     return provider.image(name);
-  });
+  }
+);
 
-modelRegistry.registerModels([
+modelRegistry.registerModels(
+  ["tts-1-hd", "tts-1", "gpt-4o-mini-tts"],
+  (name: string, options) => {
+    const provider = createOpenAI(options);
+    return provider.speech(name);
+  }
+);
+
+modelRegistry.registerModels(
+  [
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
-    "claude-3-haiku-20240307"
-  ], (name: string, options) => {
+    "claude-3-haiku-20240307",
+  ],
+  (name: string, options) => {
     const provider = createAnthropic(options);
     return provider(name);
-  });
+  }
+);
 
-export const modelProviderMap: Record<string, 'openai' | 'anthropic'> = {
+export const modelProviderMap: Record<string, "openai" | "anthropic"> = {
   // OpenAI models
   "gpt-4o": "openai",
   "gpt-4o-mini": "openai",
@@ -48,4 +64,8 @@ export const modelProviderMap: Record<string, 'openai' | 'anthropic'> = {
   "claude-3-sonnet-20240229": "anthropic",
   "claude-3-haiku-20240307": "anthropic",
 };
-export type modelConfig = 'image_config' | 'object_config' | 'text_config';
+export type modelConfig =
+  | "image_config"
+  | "object_config"
+  | "text_config"
+  | "speech_config";


### PR DESCRIPTION
## Description

This pr allows for the `agentMark` to format mdx prompts with speech config:

1. Add new schema for `speechSettings` and `speechConfig`
2. Add new format for `speechConfig`
3. Add new `loadSpeechPrompt` to `agentMark`
4. Allow returning `speechModel` when registering models
5. Allow adapting a speech config
6. Add new tests to ensure speech configs are compiled correctly
7. Refactored tests to avoid reused code
8. Add new speech compatibility to the vscode-extension

Fixes # [issue-181](https://github.com/agentmark-ai/agentmark/issues/181)

## Type of Change

- [x] New feature

## How Has This Been Tested?

Tested using the demo file in `apps/demo`
Also tested using the tests files

**NOTE**: The `vscode-extension` portion HASN'T been tested as the vscode extension isn't running on my end. This is the due to the fact that some imports and typing has been changed. I have made a pr for those changes to be applied to the `vscode-extension` so I am hoping that pr will be merged first then I will fix the merge conflicts here and test the vscode-extension

## Checklist:

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
