### PR TITLE
Feat(Support attachments): pass in attachments

### DIFF
--- a/packages/agentmark/src/index.ts
+++ b/packages/agentmark/src/index.ts
@@ -1,9 +1,9 @@
-export { createAgentMark } from './agentmark';
-export { DefaultAdapter } from './adapters/default';
-export { FileLoader } from './loaders/file';
-export { TemplateDXTemplateEngine } from './template_engines/templatedx';
+export { createAgentMark } from "./agentmark";
+export { DefaultAdapter } from "./adapters/default";
+export { FileLoader } from "./loaders/file";
+export { TemplateDXTemplateEngine } from "./template_engines/templatedx";
 
-export type { 
+export type {
   TextConfig,
   ImageConfig,
   Adapter,
@@ -12,5 +12,6 @@ export type {
   AdaptOptions,
   ObjectConfig,
   PromptShape,
-  PromptKey
-} from './types';
+  PromptKey,
+  RichChatMessage,
+} from "./types";

--- a/packages/agentmark/src/schemas.ts
+++ b/packages/agentmark/src/schemas.ts
@@ -1,11 +1,54 @@
 import { z } from "zod";
 
 export const ChatMessageSchema = z.object({
-  role: z.enum(['system', 'user', 'assistant']),
+  role: z.enum(["system", "user", "assistant"]),
   content: z.string(),
 });
 
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+export const textPartSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+export const imagePartSchema = z.object({
+  type: z.literal("image"),
+  image: z.string().url(),
+  mimeType: z.string().optional(),
+});
+
+export const filePartSchema = z.object({
+  type: z.literal("file"),
+  data: z.string().url(),
+  mimeType: z.string(),
+});
+
+export const userMessagesSchema = z.object({
+  role: z.literal("user"),
+  content: z.union([
+    z.string(),
+    z.array(z.union([textPartSchema, imagePartSchema, filePartSchema])),
+  ]),
+});
+
+export const assistantMessagesSchema = z.object({
+  role: z.literal("assistant"),
+  content: z.string(),
+});
+
+export const systemMessagesSchema = z.object({
+  role: z.literal("system"),
+  content: z.string(),
+});
+
+export const RichChatMessageSchema = z.union([
+  userMessagesSchema,
+  assistantMessagesSchema,
+  systemMessagesSchema,
+]);
+
+export type RichChatMessage = z.infer<typeof RichChatMessageSchema>;
 
 export const TextSettingsConfig = z.object({
   model_name: z.string(),
@@ -19,13 +62,15 @@ export const TextSettingsConfig = z.object({
   stop_sequences: z.array(z.string()).optional(),
   seed: z.number().optional(),
   max_retries: z.number().optional(),
-  tool_choice: z.union([
-    z.enum(['auto', 'none', 'required']),
-    z.object({
-      type: z.literal('tool'),
-      tool_name: z.string()
-    })
-  ]).optional(),
+  tool_choice: z
+    .union([
+      z.enum(["auto", "none", "required"]),
+      z.object({
+        type: z.literal("tool"),
+        tool_name: z.string(),
+      }),
+    ])
+    .optional(),
   tools: z
     .record(
       z.object({
@@ -60,8 +105,14 @@ export type ObjectSettings = z.infer<typeof ObjectSettingsConfig>;
 export const ImageSettingsConfig = z.object({
   model_name: z.string(),
   num_images: z.number().optional(),
-  size: z.string().regex(/^\d+x\d+$/).optional(),
-  aspect_ratio: z.string().regex(/^\d+:\d+$/).optional(),
+  size: z
+    .string()
+    .regex(/^\d+x\d+$/)
+    .optional(),
+  aspect_ratio: z
+    .string()
+    .regex(/^\d+:\d+$/)
+    .optional(),
   seed: z.number().optional(),
 });
 
@@ -77,7 +128,7 @@ export type TextConfig = z.infer<typeof TextConfigSchema>;
 
 export const ObjectConfigSchema = z.object({
   name: z.string(),
-  messages: z.array(ChatMessageSchema),
+  messages: z.array(RichChatMessageSchema),
   object_config: ObjectSettingsConfig,
 });
 
@@ -85,7 +136,7 @@ export type ObjectConfig = z.infer<typeof ObjectConfigSchema>;
 
 export const ImageConfigSchema = z.object({
   name: z.string(),
-  messages: z.array(ChatMessageSchema),
+  messages: z.array(RichChatMessageSchema),
   image_config: ImageSettingsConfig,
 });
 

--- a/packages/agentmark/src/types.ts
+++ b/packages/agentmark/src/types.ts
@@ -5,8 +5,9 @@ import {
   TextConfig,
   ObjectConfig,
   ImageConfig,
-  ChatMessage
-} from './schemas';
+  ChatMessage,
+  RichChatMessage,
+} from "./schemas";
 
 export type JSONPrimitive = string | number | boolean | null;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
@@ -20,26 +21,24 @@ export type {
   TextConfig,
   ImageConfig,
   ObjectConfig,
-  ChatMessage
+  ChatMessage,
+  RichChatMessage,
 };
 
 export type PromptShape<T> = { [K in keyof T]: { input: any; output: any } };
 export type PromptDict = PromptShape<any>;
 export type PromptKey<T extends PromptDict> = keyof T & string;
 
-export type PromptKind = 'object' | 'text' | 'image';
+export type PromptKind = "object" | "text" | "image";
 export type KindOf<V> = V extends { kind: infer K } ? K : PromptKind;
-export type KeysWithKind<
-  Dict,
-  K extends PromptKind,
-> = {
-  [P in keyof Dict]: K extends KindOf<Dict[P]> ? P : never
+export type KeysWithKind<Dict, K extends PromptKind> = {
+  [P in keyof Dict]: K extends KindOf<Dict[P]> ? P : never;
 }[keyof Dict];
 
 export interface TemplateEngine {
   compile<R = unknown, P extends Record<string, unknown> = JSONObject>(
     template: unknown,
-    props?: P,
+    props?: P
   ): Promise<R>;
 }
 
@@ -54,11 +53,11 @@ export type BaseAdaptOptions = {
     isEnabled: boolean;
     functionId?: string;
     metadata?: Record<string, unknown>;
-  }
+  };
   apiKey?: string;
   baseURL?: string;
   toolContext?: Record<string, unknown>;
-}
+};
 
 export type AdaptOptions = BaseAdaptOptions & { [key: string]: any };
 

--- a/packages/vercel-ai-v4-adapter/src/adapter.ts
+++ b/packages/vercel-ai-v4-adapter/src/adapter.ts
@@ -3,10 +3,11 @@ import type {
   ImageConfig,
   PromptMetadata,
   ChatMessage,
+  RichChatMessage,
   AdaptOptions,
   ObjectConfig,
   PromptShape,
-  PromptKey
+  PromptKey,
 } from "@agentmark/agentmark";
 import type {
   LanguageModel,
@@ -17,22 +18,18 @@ import type {
 } from "ai";
 import { jsonSchema } from "ai";
 
-
 type ArgOf<X> = X extends { args: infer A } ? A : never;
 
-type ToolArgs<R> =
-  R extends { __tools: { input: infer I } }
+type ToolArgs<R> = R extends { __tools: { input: infer I } }
   ? { [K in keyof I]: ArgOf<I[K]> }
   : never;
 
-type ToolRet<R> =
-  R extends { __tools: { output: infer O } } ? O : never;
+type ToolRet<R> = R extends { __tools: { output: infer O } } ? O : never;
 
-  type ToolWithExec<R> =
-  Omit<Tool<any, R>, 'execute' | 'type'> & {
-    type?: undefined | 'function';
-    execute: (args: any, options: ToolExecutionOptions) => Promise<R>;
-  };
+type ToolWithExec<R> = Omit<Tool<any, R>, "execute" | "type"> & {
+  type?: undefined | "function";
+  execute: (args: any, options: ToolExecutionOptions) => Promise<R>;
+};
 
 type ToolSetMap<O extends Record<string, any>> = {
   [K in keyof O]: ToolWithExec<O[K]>;
@@ -40,7 +37,7 @@ type ToolSetMap<O extends Record<string, any>> = {
 
 export type VercelAITextParams<TS extends Record<string, Tool>> = {
   model: LanguageModel;
-  messages: ChatMessage[];
+  messages: RichChatMessage[];
   temperature?: number;
   maxTokens?: number;
   topP?: number;
@@ -55,7 +52,7 @@ export type VercelAITextParams<TS extends Record<string, Tool>> = {
 
 export interface VercelAIObjectParams<T> {
   model: LanguageModel;
-  messages: ChatMessage[];
+  messages: RichChatMessage[];
   schema: Schema<T>;
   temperature?: number;
   maxTokens?: number;
@@ -78,12 +75,15 @@ export interface VercelAIImageParams {
   seed?: number;
 }
 
-export type ModelFunctionCreator = (modelName: string, options?: AdaptOptions) => LanguageModel | ImageModel;
+export type ModelFunctionCreator = (
+  modelName: string,
+  options?: AdaptOptions
+) => LanguageModel | ImageModel;
 
 const getTelemetryConfig = (
-  telemetry: AdaptOptions['telemetry'],
+  telemetry: AdaptOptions["telemetry"],
   props: Record<string, any>,
-  promptName: string,
+  promptName: string
 ) => {
   return {
     ...telemetry,
@@ -91,30 +91,35 @@ const getTelemetryConfig = (
       ...telemetry?.metadata,
       prompt: promptName,
       props: JSON.stringify(props),
-    }
-  }
-}
+    },
+  };
+};
 
 type Merge<A, B> = {
-  [K in keyof A | keyof B]:
-  K extends keyof B ? B[K]
-  : K extends keyof A ? A[K]
-  : never;
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+    ? A[K]
+    : never;
 };
 
 export class VercelAIToolRegistry<
   TD extends { [K in keyof TD]: { args: any } },
-  RM extends Partial<Record<keyof TD, any>> = {},
+  RM extends Partial<Record<keyof TD, any>> = {}
 > {
   declare readonly __tools: { input: TD; output: RM };
 
-  private map: { [K in keyof TD]?: (args: TD[K]['args'], toolContext?: Record<string, any>) => any } = {};
+  private map: {
+    [K in keyof TD]?: (
+      args: TD[K]["args"],
+      toolContext?: Record<string, any>
+    ) => any;
+  } = {};
 
-  register<
-    K extends keyof TD,
-    R
-  >(name: K, fn: (args: TD[K]['args'], toolContext?: Record<string, any>) => R)
-    : VercelAIToolRegistry<TD, Merge<RM, { [P in K]: R }>> {
+  register<K extends keyof TD, R>(
+    name: K,
+    fn: (args: TD[K]["args"], toolContext?: Record<string, any>) => R
+  ): VercelAIToolRegistry<TD, Merge<RM, { [P in K]: R }>> {
     this.map[name] = fn;
     return this as unknown as VercelAIToolRegistry<
       TD,
@@ -123,7 +128,10 @@ export class VercelAIToolRegistry<
   }
 
   get<K extends keyof TD & keyof RM>(name: K) {
-    return this.map[name] as (args: TD[K]['args'], toolContext?: Record<string, any>) => RM[K];
+    return this.map[name] as (
+      args: TD[K]["args"],
+      toolContext?: Record<string, any>
+    ) => RM[K];
   }
 
   has<K extends keyof TD>(name: K): name is K & keyof RM {
@@ -140,11 +148,14 @@ export class VercelAIModelRegistry {
     this.defaultCreator = defaultCreator;
   }
 
-  registerModels(modelPattern: string | RegExp | Array<string>, creator: ModelFunctionCreator): void {
-    if (typeof modelPattern === 'string') {
+  registerModels(
+    modelPattern: string | RegExp | Array<string>,
+    creator: ModelFunctionCreator
+  ): void {
+    if (typeof modelPattern === "string") {
       this.exactMatches[modelPattern] = creator;
     } else if (Array.isArray(modelPattern)) {
-      modelPattern.forEach(model => {
+      modelPattern.forEach((model) => {
         this.exactMatches[model] = creator;
       });
     } else {
@@ -177,16 +188,13 @@ export class VercelAIModelRegistry {
 
 export class VercelAIAdapter<
   T extends PromptShape<T>,
-  R extends VercelAIToolRegistry<any, any> = VercelAIToolRegistry<any, any>,
+  R extends VercelAIToolRegistry<any, any> = VercelAIToolRegistry<any, any>
 > {
   declare readonly __dict: T;
 
   private readonly toolsRegistry: R | undefined;
 
-  constructor(
-    private modelRegistry: VercelAIModelRegistry,
-    toolRegistry?: R,
-  ) {
+  constructor(private modelRegistry: VercelAIModelRegistry, toolRegistry?: R) {
     this.modelRegistry = modelRegistry;
     this.toolsRegistry = toolRegistry;
   }
@@ -194,13 +202,11 @@ export class VercelAIAdapter<
   adaptText(
     input: TextConfig,
     options: AdaptOptions,
-    metadata: PromptMetadata,
+    metadata: PromptMetadata
   ): VercelAITextParams<ToolSetMap<ToolRet<R>>> {
-
     const { model_name: name, ...settings } = input.text_config;
     const modelCreator = this.modelRegistry.getModelFunction(name);
     const model = modelCreator(name, options) as LanguageModel;
-
 
     type Args = ToolArgs<R>;
     type Ret = ToolRet<R>;
@@ -209,21 +215,21 @@ export class VercelAIAdapter<
 
     if (input.text_config.tools) {
       toolsObj = {} as ToolSetMap<Ret>;
-    
+
       for (const [keyAny, def] of Object.entries(input.text_config.tools)) {
         const key = keyAny as keyof Ret;
-    
-        const impl =
-          this.toolsRegistry?.has(key)
-            ? this.toolsRegistry.get(key)
-            : (_: any) => Promise.reject(
-                new Error(`Tool ${String(key)} not registered`),
-              );
-    
+
+        const impl = this.toolsRegistry?.has(key)
+          ? this.toolsRegistry.get(key)
+          : (_: any) =>
+              Promise.reject(new Error(`Tool ${String(key)} not registered`));
+
         (toolsObj as any)[key] = {
-          parameters : jsonSchema(def.parameters),
-          description: def.description ?? '',
-          execute    : ((args) => impl(args, options.toolContext)) as ToolWithExec<Ret[typeof key]>['execute'],
+          parameters: jsonSchema(def.parameters),
+          description: def.description ?? "",
+          execute: ((args) => impl(args, options.toolContext)) as ToolWithExec<
+            Ret[typeof key]
+          >["execute"],
         } satisfies ToolWithExec<Ret[typeof key]>;
       }
     }
@@ -231,15 +237,33 @@ export class VercelAIAdapter<
     return {
       model,
       messages: input.messages,
-      ...(settings?.temperature !== undefined ? { temperature: settings.temperature } : {}),
-      ...(settings?.max_tokens !== undefined ? { maxTokens: settings.max_tokens } : {}),
+      ...(settings?.temperature !== undefined
+        ? { temperature: settings.temperature }
+        : {}),
+      ...(settings?.max_tokens !== undefined
+        ? { maxTokens: settings.max_tokens }
+        : {}),
       ...(settings?.top_p !== undefined ? { topP: settings.top_p } : {}),
       ...(settings?.top_k !== undefined ? { topK: settings.top_k } : {}),
-      ...(settings?.frequency_penalty !== undefined ? { frequencyPenalty: settings.frequency_penalty } : {}),
-      ...(settings?.presence_penalty !== undefined ? { presencePenalty: settings.presence_penalty } : {}),
-      ...(settings?.stop_sequences !== undefined ? { stopSequences: settings.stop_sequences } : {}),
+      ...(settings?.frequency_penalty !== undefined
+        ? { frequencyPenalty: settings.frequency_penalty }
+        : {}),
+      ...(settings?.presence_penalty !== undefined
+        ? { presencePenalty: settings.presence_penalty }
+        : {}),
+      ...(settings?.stop_sequences !== undefined
+        ? { stopSequences: settings.stop_sequences }
+        : {}),
       ...(settings?.seed !== undefined ? { seed: settings.seed } : {}),
-      ...(options.telemetry ? { experimental_telemetry: getTelemetryConfig(options.telemetry, metadata.props, input.name) } : {}),
+      ...(options.telemetry
+        ? {
+            experimental_telemetry: getTelemetryConfig(
+              options.telemetry,
+              metadata.props,
+              input.name
+            ),
+          }
+        : {}),
       tools: toolsObj ?? ({} as ToolSetMap<Ret>),
     };
   }
@@ -257,35 +281,56 @@ export class VercelAIAdapter<
       model,
       messages: input.messages,
       schema: jsonSchema(input.object_config.schema),
-      ...(settings?.temperature !== undefined ? { temperature: settings.temperature } : {}),
-      ...(settings?.max_tokens !== undefined ? { maxTokens: settings.max_tokens } : {}),
+      ...(settings?.temperature !== undefined
+        ? { temperature: settings.temperature }
+        : {}),
+      ...(settings?.max_tokens !== undefined
+        ? { maxTokens: settings.max_tokens }
+        : {}),
       ...(settings?.top_p !== undefined ? { topP: settings.top_p } : {}),
       ...(settings?.top_k !== undefined ? { topK: settings.top_k } : {}),
-      ...(settings?.frequency_penalty !== undefined ? { frequencyPenalty: settings.frequency_penalty } : {}),
-      ...(settings?.presence_penalty !== undefined ? { presencePenalty: settings.presence_penalty } : {}),
+      ...(settings?.frequency_penalty !== undefined
+        ? { frequencyPenalty: settings.frequency_penalty }
+        : {}),
+      ...(settings?.presence_penalty !== undefined
+        ? { presencePenalty: settings.presence_penalty }
+        : {}),
       ...(settings?.seed !== undefined ? { seed: settings.seed } : {}),
-      ...(settings?.schema_name !== undefined ? { schemaName: settings.schema_name } : {}),
-      ...(settings?.schema_description !== undefined ? { schemaDescription: settings.schema_description } : {}),
-      ...(options.telemetry ? { experimental_telemetry: getTelemetryConfig(options.telemetry, metadata.props, input.name) } : {})
+      ...(settings?.schema_name !== undefined
+        ? { schemaName: settings.schema_name }
+        : {}),
+      ...(settings?.schema_description !== undefined
+        ? { schemaDescription: settings.schema_description }
+        : {}),
+      ...(options.telemetry
+        ? {
+            experimental_telemetry: getTelemetryConfig(
+              options.telemetry,
+              metadata.props,
+              input.name
+            ),
+          }
+        : {}),
     };
   }
 
-  adaptImage(
-    input: ImageConfig,
-    options: AdaptOptions,
-  ): VercelAIImageParams {
+  adaptImage(input: ImageConfig, options: AdaptOptions): VercelAIImageParams {
     const { model_name: name, ...settings } = input.image_config;
     const modelCreator = this.modelRegistry.getModelFunction(name);
     const model = modelCreator(name, options) as ImageModel;
-    const prompt = input.messages.map(message => message.content).join('\n');
+    const prompt = input.messages.map((message) => message.content).join("\n");
 
     return {
       model,
       prompt,
       ...(settings?.num_images !== undefined ? { n: settings.num_images } : {}),
-      ...(settings?.size !== undefined ? { size: settings.size as `${number}x${number}` } : {}),
-      ...(settings?.aspect_ratio !== undefined ? { aspectRatio: settings.aspect_ratio as `${number}:${number}` } : {}),
-      ...(settings?.seed !== undefined ? { seed: settings.seed } : {})
+      ...(settings?.size !== undefined
+        ? { size: settings.size as `${number}x${number}` }
+        : {}),
+      ...(settings?.aspect_ratio !== undefined
+        ? { aspectRatio: settings.aspect_ratio as `${number}:${number}` }
+        : {}),
+      ...(settings?.seed !== undefined ? { seed: settings.seed } : {}),
     };
   }
 }


### PR DESCRIPTION
## Description

Support passing in attachments to text and object generation.

1. Changed the messages type to support the defined user messages on [vercel AI SDK:](https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-object#messages.core-user-message.content)
2. Changed the handling for extracting user messages in templateDX 

Fixes #192

## How Has This Been Tested?

So far has done the testing primarily through the index file but I am working on the test files right now
Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
