### PR TITLE
feat-176: display images and audio using webview

### DIFF
--- a/.changeset/hungry-candies-speak.md
+++ b/.changeset/hungry-candies-speak.md
@@ -1,0 +1,7 @@
+---
+"@agentmark/vercel-ai-v4-adapter": patch
+"@agentmark/default-adapter": patch
+"@agentmark/agentmark-core": patch
+---
+
+Fix: type issue in agentmark loaders

--- a/.changeset/some-showers-guess.md
+++ b/.changeset/some-showers-guess.md
@@ -1,0 +1,5 @@
+---
+"agentmark": patch
+---
+
+Display images and audio in webview

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -8,10 +8,11 @@ import {
   streamText,
 } from "ai";
 import { getFrontMatter, load } from "@agentmark/templatedx";
-import { modelConfig, modelRegistry, modelProviderMap } from "./modelRegistry";
+import { modelRegistry, modelProviderMap } from "./modelRegistry";
 import { loadOldFormat } from "./loadOldFormat";
-import type { Root } from "mdast";
 import { audioHtmlFormat, imageHtmlFormat } from "./formatWebView";
+import type { Root } from "mdast";
+import type { PromptKind } from "@agentmark/agentmark-core";
 
 const templateEngine = new TemplateDXTemplateEngine();
 export function activate(context: vscode.ExtensionContext) {
@@ -41,28 +42,29 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const compiledYaml = await templateEngine.compile({ template: ast });
-      let modelConfig: modelConfig | undefined;
-      let model: any;
+      let promptKind: PromptKind | undefined;
+      //TODO: Refactor to use a stricter type and rename config to settings
+      let promptConfig: any;
 
       if (compiledYaml?.image_config) {
-        modelConfig = "image_config";
-        model = compiledYaml.image_config;
+        promptKind = "image";
+        promptConfig = compiledYaml.image_config;
       } else if (compiledYaml?.object_config) {
-        modelConfig = "object_config";
-        model = compiledYaml.object_config;
+        promptKind = "object";
+        promptConfig = compiledYaml.object_config;
       } else if (compiledYaml?.text_config) {
-        modelConfig = "text_config";
-        model = compiledYaml.text_config;
+        promptKind = "text";
+        promptConfig = compiledYaml.text_config;
       } else if (compiledYaml?.speech_config) {
-        modelConfig = "speech_config";
-        model = compiledYaml.speech_config;
+        promptKind = "speech";
+        promptConfig = compiledYaml.speech_config;
       } else {
         return vscode.window.showErrorMessage(
           "No config (image_config, object_config, text_config, or speech_config) found in the file."
         );
       }
 
-      const modelName = model?.model_name || "";
+      const modelName: string = promptConfig?.model_name || "";
 
       let apiKey = await context.secrets.get(
         `agentmark.${modelProviderMap[modelName]}`
@@ -91,9 +93,8 @@ export function activate(context: vscode.ExtensionContext) {
         const ch = vscode.window.createOutputChannel("AgentMark");
 
         ch.appendLine("Generating Response...");
-        switch (modelConfig) {
-          case "image_config": {
-            //@ts-ignore
+        switch (promptKind) {
+          case "image": {
             const prompt = await agentMark.loadImagePrompt(ast);
             const vercelInput = await prompt.format({ props, apiKey });
             const imageResult = await generateImage(vercelInput);
@@ -108,8 +109,7 @@ export function activate(context: vscode.ExtensionContext) {
             panel.webview.html = imageHtmlFormat(imageResult.images);
             break;
           }
-          case "speech_config": {
-            //@ts-ignore
+          case "speech": {
             const prompt = await agentMark.loadSpeechPrompt(ast);
             const vercelInput = await prompt.format({ props, apiKey });
             const speechResult = await generateSpeech(vercelInput);
@@ -123,8 +123,7 @@ export function activate(context: vscode.ExtensionContext) {
             panel.webview.html = audioHtmlFormat(speechResult.audio);
             break;
           }
-          case "object_config": {
-            //@ts-ignore
+          case "object": {
             const prompt = await agentMark.loadObjectPrompt(ast);
             const vercelInput = await prompt.format({ props, apiKey });
             const { partialObjectStream: objectStream } = streamObject(
@@ -154,8 +153,7 @@ export function activate(context: vscode.ExtensionContext) {
             break;
           }
 
-          case "text_config": {
-            //@ts-ignore
+          case "text": {
             const prompt = await agentMark.loadTextPrompt(ast);
             const vercelInput = await prompt.format({ props, apiKey });
             const { textStream } = streamText(vercelInput);

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -44,8 +44,6 @@ export function activate(context: vscode.ExtensionContext) {
       let modelConfig: modelConfig | undefined;
       let model: any;
 
-      modelConfig = "image_config";
-
       if (compiledYaml?.image_config) {
         modelConfig = "image_config";
         model = compiledYaml.image_config;

--- a/apps/vscode-extension/src/formatWebView.ts
+++ b/apps/vscode-extension/src/formatWebView.ts
@@ -1,0 +1,62 @@
+import type { GeneratedFile, GeneratedAudioFile } from "ai";
+
+export const imageHtmlFormat = (images: GeneratedFile[]) => {
+  if (!images.length) {
+    return noGeneratedFileHtml("No Generated Images");
+  }
+
+  const imageListHtml = imagesHtml(images);
+  return `
+  <html>
+    <body style="margin:0;padding:20px;font-family:sans-serif;">
+      <h1>Generated Images</h1>
+      ${imageListHtml}
+    </body>
+  </html>
+`;
+};
+
+const imagesHtml = (images: GeneratedFile[]): string => {
+  return images
+    .map(
+      (image, index) => `
+    <div class="image-container" style="margin-bottom: 20px;">
+      <p>Image ${index + 1}</p>
+      <img src="data:${image.mimeType};base64,${image.base64}" 
+      alt="Image" style="max-width:100%;height:auto;" />
+      <br />
+    </div>
+    `
+    )
+    .join("");
+};
+
+const noGeneratedFileHtml = (errorMessage: string): string =>
+  `
+  <html>
+    <body style="margin:0;padding:20px;font-family:sans-serif;">
+      <h1>${errorMessage}</h1>
+    </body>
+  </html>
+`;
+
+export const audioHtmlFormat = (audios: GeneratedAudioFile): string => {
+  if (!audios) {
+    return noGeneratedFileHtml("No Generated Audio File");
+  }
+
+  return `
+    <html>
+      <body style="margin:0;padding:20px;font-family:sans-serif;">
+        <h1>Generated Audio</h1>
+          <div class="audio-container" style="margin-bottom: 20px;">
+            <p>Audio File</p>
+            <audio controls style="width: 100%;">
+              <source src="data:${audios.mimeType};base64,${audios.base64}" type="${audios.mimeType}">
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+      </body>
+    </html>
+  `;
+};

--- a/apps/vscode-extension/src/modelRegistry.ts
+++ b/apps/vscode-extension/src/modelRegistry.ts
@@ -64,8 +64,3 @@ export const modelProviderMap: Record<string, "openai" | "anthropic"> = {
   "claude-3-sonnet-20240229": "anthropic",
   "claude-3-haiku-20240307": "anthropic",
 };
-export type modelConfig =
-  | "image_config"
-  | "object_config"
-  | "text_config"
-  | "speech_config";

--- a/packages/agentmark-core/src/agentmark.ts
+++ b/packages/agentmark-core/src/agentmark.ts
@@ -1,11 +1,4 @@
 import {
-  Loader,
-  TemplateEngine,
-  Adapter,
-  PromptShape,
-  KeysWithKind,
-} from "./types";
-import {
   ImageConfigSchema,
   ObjectConfigSchema,
   TextConfigSchema,
@@ -13,6 +6,14 @@ import {
 } from "./schemas";
 import { TemplateDXTemplateEngine } from "./template_engines/templatedx";
 import { ObjectPrompt, ImagePrompt, TextPrompt, SpeechPrompt } from "./prompts";
+import type {
+  Loader,
+  TemplateEngine,
+  Adapter,
+  PromptShape,
+  KeysWithKind,
+} from "./types";
+import type { Root } from "mdast";
 
 export interface AgentMarkOptions<
   T extends PromptShape<T>,
@@ -35,12 +36,13 @@ export class AgentMark<T extends PromptShape<T>, A extends Adapter<T>> {
   }
 
   async loadTextPrompt<K extends KeysWithKind<T, "text"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ) {
     let content: unknown;
+    const pathProvided = typeof pathOrPreloaded === "string";
 
-    if (typeof pathOrPreloaded === "string" && this.loader) {
+    if (pathProvided && this.loader) {
       content = await this.loader.load(pathOrPreloaded, options);
     } else {
       content = pathOrPreloaded;
@@ -49,24 +51,24 @@ export class AgentMark<T extends PromptShape<T>, A extends Adapter<T>> {
     TextConfigSchema.parse(
       await this.templateEngine.compile({
         template: content,
-        configType: "text",
       })
     );
     return new TextPrompt<T, A, K>(
       content,
       this.templateEngine,
       this.adapter,
-      pathOrPreloaded
+      pathProvided ? pathOrPreloaded : undefined
     );
   }
 
   async loadObjectPrompt<K extends KeysWithKind<T, "object"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ) {
     let content: unknown;
+    const pathProvided = typeof pathOrPreloaded === "string";
 
-    if (typeof pathOrPreloaded === "string" && this.loader) {
+    if (pathProvided && this.loader) {
       content = await this.loader.load(pathOrPreloaded, options);
     } else {
       content = pathOrPreloaded;
@@ -75,24 +77,24 @@ export class AgentMark<T extends PromptShape<T>, A extends Adapter<T>> {
     ObjectConfigSchema.parse(
       await this.templateEngine.compile({
         template: content,
-        configType: "object",
       })
     );
     return new ObjectPrompt<T, A, K>(
       content,
       this.templateEngine,
       this.adapter,
-      pathOrPreloaded
+      pathProvided ? pathOrPreloaded : undefined
     );
   }
 
   async loadImagePrompt<K extends KeysWithKind<T, "image"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ) {
     let content: unknown;
+    const pathProvided = typeof pathOrPreloaded === "string";
 
-    if (typeof pathOrPreloaded === "string" && this.loader) {
+    if (pathProvided && this.loader) {
       content = await this.loader.load(pathOrPreloaded, options);
     } else {
       content = pathOrPreloaded;
@@ -101,24 +103,24 @@ export class AgentMark<T extends PromptShape<T>, A extends Adapter<T>> {
     ImageConfigSchema.parse(
       await this.templateEngine.compile({
         template: content,
-        configType: "image",
       })
     );
     return new ImagePrompt<T, A, K>(
       content,
       this.templateEngine,
       this.adapter,
-      pathOrPreloaded
+      pathProvided ? pathOrPreloaded : undefined
     );
   }
 
   async loadSpeechPrompt<K extends KeysWithKind<T, "speech"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ) {
     let content: unknown;
+    const pathProvided = typeof pathOrPreloaded === "string";
 
-    if (typeof pathOrPreloaded === "string" && this.loader) {
+    if (pathProvided && this.loader) {
       content = await this.loader.load(pathOrPreloaded, options);
     } else {
       content = pathOrPreloaded;
@@ -127,14 +129,13 @@ export class AgentMark<T extends PromptShape<T>, A extends Adapter<T>> {
     SpeechConfigSchema.parse(
       await this.templateEngine.compile({
         template: content,
-        configType: "speech",
       })
     );
     return new SpeechPrompt<T, A, K>(
       content,
       this.templateEngine,
       this.adapter,
-      pathOrPreloaded
+      pathProvided ? pathOrPreloaded : undefined
     );
   }
 }

--- a/packages/agentmark-core/src/index.ts
+++ b/packages/agentmark-core/src/index.ts
@@ -21,4 +21,5 @@ export type {
   KeysWithKind,
   TemplateEngine,
   Loader,
+  PromptKind,
 } from "./types";

--- a/packages/agentmark-core/src/prompts/index.ts
+++ b/packages/agentmark-core/src/prompts/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Adapter,
   AdaptOptions,
   PromptMetadata,
@@ -25,16 +25,15 @@ export abstract class BasePrompt<
     public readonly template: unknown,
     engine: TemplateEngine,
     protected readonly adapter: A,
-    protected readonly path: K
+    protected readonly path?: K
   ) {
     this.templateEngine = engine;
   }
 
-  protected compile(props: T[K]["input"], configType: PromptKind): Promise<C> {
+  protected compile(props: T[K]["input"]): Promise<C> {
     return this.templateEngine.compile<C, T[K]["input"]>({
       template: this.template,
       props,
-      configType,
     });
   }
 
@@ -52,7 +51,7 @@ export class ObjectPrompt<
   A extends Adapter<T>,
   K extends KeysWithKind<T, "object"> & string
 > extends BasePrompt<T, A, K, ObjectConfig> {
-  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path: K) {
+  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path?: K) {
     super(tpl, eng, ad, path);
   }
 
@@ -60,7 +59,7 @@ export class ObjectPrompt<
     props,
     ...options
   }: PromptFormatParams<T[K]["input"]>): Promise<ReturnType<A["adaptObject"]>> {
-    const compiled = await this.compile(props, "object");
+    const compiled = await this.compile(props);
     return this.adapter.adaptObject(compiled, options, this.metadata(props));
   }
 }
@@ -70,7 +69,7 @@ export class TextPrompt<
   A extends Adapter<T>,
   K extends KeysWithKind<T, "text"> & string
 > extends BasePrompt<T, A, K, TextConfig> {
-  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path: K) {
+  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path?: K) {
     super(tpl, eng, ad, path);
   }
 
@@ -78,7 +77,7 @@ export class TextPrompt<
     props,
     ...options
   }: PromptFormatParams<T[K]["input"]>): Promise<ReturnType<A["adaptText"]>> {
-    const compiled = await this.compile(props, "text");
+    const compiled = await this.compile(props);
     return this.adapter.adaptText<K>(compiled, options, this.metadata(props));
   }
 }
@@ -88,7 +87,7 @@ export class ImagePrompt<
   A extends Adapter<T>,
   K extends KeysWithKind<T, "image"> & string
 > extends BasePrompt<T, A, K, ImageConfig> {
-  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path: K) {
+  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path?: K) {
     super(tpl, eng, ad, path);
   }
 
@@ -96,7 +95,7 @@ export class ImagePrompt<
     props,
     ...options
   }: PromptFormatParams<T[K]["input"]>): Promise<ReturnType<A["adaptImage"]>> {
-    const compiled = await this.compile(props, "image");
+    const compiled = await this.compile(props);
     return this.adapter.adaptImage(compiled, options, this.metadata(props));
   }
 }
@@ -106,7 +105,7 @@ export class SpeechPrompt<
   A extends Adapter<T>,
   K extends KeysWithKind<T, "speech"> & string
 > extends BasePrompt<T, A, K, SpeechConfig> {
-  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path: K) {
+  constructor(tpl: unknown, eng: TemplateEngine, ad: A, path?: K) {
     super(tpl, eng, ad, path);
   }
 
@@ -114,7 +113,7 @@ export class SpeechPrompt<
     props,
     ...options
   }: PromptFormatParams<T[K]["input"]>): Promise<ReturnType<A["adaptSpeech"]>> {
-    const compiled = await this.compile(props, "speech");
+    const compiled = await this.compile(props);
     return this.adapter.adaptSpeech(compiled, options, this.metadata(props));
   }
 }

--- a/packages/agentmark-core/src/template_engines/templatedx.ts
+++ b/packages/agentmark-core/src/template_engines/templatedx.ts
@@ -71,7 +71,7 @@ export class ExtractTextPlugin extends TagPlugin {
           children: flattenedChildren,
         });
 
-        const mediaParts = scope.getShared("__puzzlet-mediaParts") || [];
+        const mediaParts = scope.getShared("__agentmark-mediaParts") || [];
         const hasMediaContent = tagName === USER && mediaParts.length;
         const content = hasMediaContent
           ? [{ type: "text", text: extractedText.trim() }, ...media]
@@ -86,7 +86,7 @@ export class ExtractTextPlugin extends TagPlugin {
       }
     });
 
-    const media = scope.getShared("__puzzlet-mediaParts") || [];
+    const media = scope.getShared("__agentmark-mediaParts") || [];
     const promises = scope.getShared("__agentmark-extractTextPromises");
     if (!promises) {
       scope.setShared("__agentmark-extractTextPromises", [promise]);
@@ -99,7 +99,7 @@ export class ExtractTextPlugin extends TagPlugin {
 }
 
 export class ExtractMediaPlugin extends TagPlugin {
-  private readonly key = "__puzzlet-mediaParts";
+  private readonly key = "__agentmark-mediaParts";
   async transform(
     props: Record<string, any>,
     _children: Node[],

--- a/packages/agentmark-core/src/template_engines/templatedx.ts
+++ b/packages/agentmark-core/src/template_engines/templatedx.ts
@@ -300,6 +300,24 @@ export async function getRawConfig({
 
   const name: string = frontMatter.name;
 
+  if (!configType) {
+    // If no configType is provided, we will return everything found from frontmatter.
+    return {
+      name: frontMatter.name,
+      messages: [],
+      ...(frontMatter.image_config && {
+        image_config: frontMatter.image_config,
+      }),
+      ...(frontMatter.object_config && {
+        object_config: frontMatter.object_config,
+      }),
+      ...(frontMatter.text_config && { text_config: frontMatter.text_config }),
+      ...(frontMatter.speech_config && {
+        speech_config: frontMatter.speech_config,
+      }),
+    };
+  }
+
   let prompt: string | undefined;
   let instructions: string | undefined;
   let messages: RichChatMessage[] = [];
@@ -317,7 +335,6 @@ export async function getRawConfig({
   let imageSettings: ImageSettings | undefined = frontMatter.image_config;
   let objectSettings: ObjectSettings | undefined = frontMatter.object_config;
   let textSettings: TextSettings | undefined = frontMatter.text_config;
-
   switch (configType) {
     case "speech": {
       if (speechSettings && prompt) {

--- a/packages/agentmark-core/src/types.ts
+++ b/packages/agentmark-core/src/types.ts
@@ -52,7 +52,6 @@ export interface TemplateEngine {
   >(options: {
     template: unknown;
     props?: P;
-    configType?: PromptKind;
   }): Promise<R>;
 }
 

--- a/packages/agentmark-core/test/agentmark.test.ts
+++ b/packages/agentmark-core/test/agentmark.test.ts
@@ -86,7 +86,7 @@ describe("AgentMark Integration", () => {
     );
     expect(result.image_config.model_name).toBe("test-model");
     expect(result.image_config.num_images).toBe(1);
-    expect(result.image_config.size).toBe("512x512");
+    expect(result.image_config.size).toBe("1024x1024");
     expect(result.image_config.aspect_ratio).toBe("1:1");
     expect(result.image_config.seed).toBe(12345);
   });

--- a/packages/agentmark-core/test/fixtures/image.prompt.mdx
+++ b/packages/agentmark-core/test/fixtures/image.prompt.mdx
@@ -3,7 +3,7 @@ name: image
 image_config:
   model_name: test-model
   num_images: 1
-  size: 512x512
+  size: 1024x1024
   aspect_ratio: 1:1
   seed: 12345
 input_schema:

--- a/packages/default-adapter/src/index.ts
+++ b/packages/default-adapter/src/index.ts
@@ -7,6 +7,7 @@ import {
   PromptShape,
 } from "@agentmark/agentmark-core";
 import { DefaultAdapter } from "./adapter";
+import type { Root } from "mdast";
 
 export interface DefaultObjectPrompt<
   T extends PromptShape<T>,
@@ -21,7 +22,7 @@ export interface DefaultObjectPrompt<
 export interface DefaultAgentmark<T extends PromptShape<T>>
   extends AgentMark<T, DefaultAdapter<T>> {
   loadObjectPrompt<K extends KeysWithKind<T, "object"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ): Promise<DefaultObjectPrompt<T, DefaultAdapter<T>, K>>;
 }

--- a/packages/vercel-ai-v4-adapter/src/index.ts
+++ b/packages/vercel-ai-v4-adapter/src/index.ts
@@ -12,6 +12,7 @@ import {
   VercelAIObjectParams,
   VercelAIToolRegistry,
 } from "./adapter";
+import type { Root } from "mdast";
 
 export interface VercelAIObjectPrompt<
   T extends PromptShape<T>,
@@ -28,7 +29,7 @@ export interface VercelAgentMark<
   Tools extends VercelAIToolRegistry<any, any>
 > extends AgentMark<T, VercelAIAdapter<T, Tools>> {
   loadObjectPrompt<K extends KeysWithKind<T, "object"> & string>(
-    pathOrPreloaded: K,
+    pathOrPreloaded: K | Root,
     options?: any
   ): Promise<VercelAIObjectPrompt<T, K, Tools>>;
 }


### PR DESCRIPTION
## Description

Allow viewing images and audio file generated using `webview` from `vscode.` We are doing this by creating a custom `html` and we imped an `audio` or an `image` inside of it -> display to users.

- Many images can be generated so images will be divided by a simple div in between them with a small header that states the image and its index
- Audio will have one audio generated and it will display the audio generated using audioControls.
- `ast` was defined as `any` but now will be correctly defined as `Root`. This caused a regression from [pull0191](https://github.com/agentmark-ai/agentmark/pull/191) where we passed in `ast` to the new object parameter instead of passing it in as the template property.
- Fix another issue where we need to return all of the config found in the `frontMatter` if no `configType` was passed

Fixes #176 

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

**Testing Steps**
1. Ensure you have yalc downloaded globally
2. go to `agentmark-core`  and `vercel-ai-v4-adapter`
3. run `yarn build` -> `yalc publish` on both
4. open vscode extension folder in a vscode window alone
5. run `yalc link @agentmark/agentmark-core` && `yalc link @agentmark/vercel-ai-v4-adapter`
6. `yarn` -> `yarn compile`
7. `F5` or debug
8. Run an mdx file for images or speech
9. new panel should open up for view

## Checklist:

- [ ] I have updated the documentation accordingly. NA
- [ ] I have added tests to cover my changes. NA
- [x] All new and existing tests passed.

##Images of the changes
![Screenshot 2025-05-29 225530](https://github.com/user-attachments/assets/f2d5bd67-ae63-4b84-829a-ec631d6cbb38)

![Screenshot 2025-05-29 225935](https://github.com/user-attachments/assets/82b88be5-0040-471d-a37b-e961361ec708)
