### PR TITLE
Add mastra adapter to agentmark

### DIFF
--- a/packages/mastra-adapter/CHANGELOG.md
+++ b/packages/mastra-adapter/CHANGELOG.md
@@ -1,0 +1,25 @@
+# @agentmark/mastra-adapter
+
+## 3.3.0
+
+### Added
+
+- ✨ Initial release of Mastra adapter for AgentMark
+- 🤖 Support for Mastra agents with text generation
+- 🎯 Structured output with schema validation  
+- 🖼️ Image generation capabilities
+- 🎤 Speech and audio generation support
+- 🔧 Tool calling and function execution
+- 🧠 Memory and context management integration
+- 🔄 Workflow system integration
+- 📚 Comprehensive TypeScript types and interfaces
+- 🛠️ Agent registry for dynamic model routing
+- 🔌 Tool registry for extensible functionality
+
+### Features
+
+- **MastraAdapter**: Core adapter implementing AgentMark interfaces
+- **MastraAgentRegistry**: Registry for managing Mastra agents by name or pattern
+- **MastraToolRegistry**: Registry for managing tools and functions
+- **createAgentMarkClient**: Factory function for creating AgentMark clients
+- Full compatibility with Mastra's Agent, Tool, and Workflow systems

--- a/packages/mastra-adapter/README.md
+++ b/packages/mastra-adapter/README.md
@@ -1,0 +1,50 @@
+# @agentmark/mastra-adapter
+
+AgentMark adapter for [Mastra](https://mastra.ai/) - the TypeScript AI agent framework.
+
+## Installation
+
+```bash
+npm install @agentmark/mastra-adapter @mastra/core
+```
+
+## Usage
+
+```typescript
+import { createAgentMarkClient, MastraAgentRegistry } from '@agentmark/mastra-adapter';
+import { Agent } from '@mastra/core';
+import { openai } from '@ai-sdk/openai';
+
+// Create an agent registry
+const agentRegistry = new MastraAgentRegistry();
+
+// Register agents
+agentRegistry.registerAgents('gpt-4o-mini', (name, instructions, model, options) => {
+  return new Agent({
+    name,
+    instructions,
+    model: openai('gpt-4o-mini'),
+    // Add other Mastra agent options
+  });
+});
+
+// Create AgentMark client
+const client = createAgentMarkClient({
+  agentRegistry,
+  // toolRegistry: optional tool registry
+});
+
+// Use with AgentMark prompts
+const prompt = await client.loadObjectPrompt('my-prompt');
+const result = await prompt.format({ /* your data */ });
+```
+
+## Features
+
+- ✅ Text generation with Mastra agents
+- ✅ Object/structured output with schema validation
+- ✅ Image generation support
+- ✅ Speech/audio generation support
+- ✅ Tool calling integration
+- ✅ Memory and context management
+- ✅ Workflow integration

--- a/packages/mastra-adapter/package.json
+++ b/packages/mastra-adapter/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@agentmark/mastra-adapter",
+  "version": "3.3.0",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build": "tsup && npx cpy ../../README.md ../../logo.svg ./"
+  },
+  "devDependencies": {
+    "@agentmark/agentmark-core": "^3.3.0",
+    "@types/node": "^22.8.1",
+    "@types/react": "^18",
+    "cpy-cli": "^5.0.0",
+    "react": "^18.3.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.2",
+    "vitest": "^3.0.8"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "@agentmark/agentmark-core": "^3.2.0",
+    "@mastra/core": "^1.0.0"
+  },
+  "files": [
+    "dist/"
+  ]
+}

--- a/packages/mastra-adapter/src/adapter.ts
+++ b/packages/mastra-adapter/src/adapter.ts
@@ -1,0 +1,318 @@
+import type {
+  TextConfig,
+  ImageConfig,
+  PromptMetadata,
+  RichChatMessage,
+  AdaptOptions,
+  ObjectConfig,
+  PromptShape,
+  KeysWithKind,
+  SpeechConfig,
+} from "@agentmark/agentmark-core";
+import { Agent } from "@mastra/core";
+import { createTool } from "@mastra/core";
+import { z } from "zod";
+
+type ToolRet<R> = R extends { __tools: { output: infer O } } ? O : never;
+
+type ToolWithExec<R> = {
+  id: string;
+  description: string;
+  inputSchema: z.ZodSchema<any>;
+  outputSchema?: z.ZodSchema<R>;
+  execute: (args: any) => Promise<R>;
+};
+
+type ToolSetMap<O extends Record<string, any>> = {
+  [K in keyof O]: ToolWithExec<O[K]>;
+};
+
+export type MastraTextParams<TS extends Record<string, any>> = {
+  agent: Agent;
+  messages: RichChatMessage[];
+  tools?: TS;
+};
+
+export interface MastraObjectParams<T> {
+  agent: Agent;
+  messages: RichChatMessage[];
+  schema: z.ZodSchema<T>;
+  schemaName?: string;
+  schemaDescription?: string;
+}
+
+export interface MastraImageParams {
+  agent: Agent;
+  prompt: string;
+  n?: number;
+  size?: `${number}x${number}`;
+  aspectRatio?: `${number}:${number}`;
+  seed?: number;
+}
+
+export interface MastraSpeechParams {
+  agent: Agent;
+  text: string;
+  voice?: string;
+  outputFormat?: string;
+  instructions?: string;
+  speed?: number;
+}
+
+export type AgentFunction = (
+  name: string,
+  instructions: string,
+  model: any,
+  options?: AdaptOptions
+) => Agent;
+
+const getTelemetryConfig = (
+  telemetry: AdaptOptions["telemetry"],
+  props: Record<string, any>,
+  promptName: string
+) => {
+  return {
+    ...telemetry,
+    metadata: {
+      ...telemetry?.metadata,
+      prompt: promptName,
+      props: JSON.stringify(props),
+    },
+  };
+};
+
+type Merge<A, B> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+    ? A[K]
+    : never;
+};
+
+export class MastraToolRegistry<
+  TD extends { [K in keyof TD]: { args: any } },
+  RM extends Partial<Record<keyof TD, any>> = {}
+> {
+  declare readonly __tools: { input: TD; output: RM };
+
+  private map: {
+    [K in keyof TD]?: (
+      args: TD[K]["args"],
+      toolContext?: Record<string, any>
+    ) => any;
+  } = {};
+
+  register<K extends keyof TD, R>(
+    name: K,
+    fn: (args: TD[K]["args"], toolContext?: Record<string, any>) => R
+  ): MastraToolRegistry<TD, Merge<RM, { [P in K]: R }>> {
+    this.map[name] = fn;
+    return this as unknown as MastraToolRegistry<
+      TD,
+      Merge<RM, { [P in K]: R }>
+    >;
+  }
+
+  get<K extends keyof TD & keyof RM>(name: K) {
+    return this.map[name] as (
+      args: TD[K]["args"],
+      toolContext?: Record<string, any>
+    ) => RM[K];
+  }
+
+  has<K extends keyof TD>(name: K): name is K & keyof RM {
+    return name in this.map;
+  }
+}
+
+export class MastraAgentRegistry {
+  private exactMatches: Record<string, AgentFunction> = {};
+  private patternMatches: Array<[RegExp, AgentFunction]> = [];
+  private defaultCreator?: AgentFunction;
+
+  constructor(defaultCreator?: AgentFunction) {
+    this.defaultCreator = defaultCreator;
+  }
+
+  registerAgents(
+    agentPattern: string | RegExp | Array<string>,
+    creator: AgentFunction
+  ): void {
+    if (typeof agentPattern === "string") {
+      this.exactMatches[agentPattern] = creator;
+    } else if (Array.isArray(agentPattern)) {
+      agentPattern.forEach((agent) => {
+        this.exactMatches[agent] = creator;
+      });
+    } else {
+      this.patternMatches.push([agentPattern, creator]);
+    }
+  }
+
+  getAgentFunction(agentName: string): AgentFunction {
+    if (this.exactMatches[agentName]) {
+      return this.exactMatches[agentName];
+    }
+
+    for (const [pattern, creator] of this.patternMatches) {
+      if (pattern.test(agentName)) {
+        return creator;
+      }
+    }
+
+    if (this.defaultCreator) {
+      return this.defaultCreator;
+    }
+
+    throw new Error(`No agent function found for: ${agentName}`);
+  }
+
+  setDefaultCreator(creator: AgentFunction): void {
+    this.defaultCreator = creator;
+  }
+}
+
+export class MastraAdapter<
+  T extends PromptShape<T>,
+  R extends MastraToolRegistry<any, any> = MastraToolRegistry<any, any>
+> {
+  declare readonly __dict: T;
+  readonly __name = "mastra";
+
+  private readonly toolsRegistry: R | undefined;
+
+  constructor(private agentRegistry: MastraAgentRegistry, toolRegistry?: R) {
+    this.agentRegistry = agentRegistry;
+    this.toolsRegistry = toolRegistry;
+  }
+
+  adaptText<K extends KeysWithKind<T, "text"> & string>(
+    input: TextConfig,
+    options: AdaptOptions,
+    metadata: PromptMetadata
+  ): MastraTextParams<ToolSetMap<ToolRet<R>>> {
+    const { model_name: name, ...settings } = input.text_config;
+    const agentCreator = this.agentRegistry.getAgentFunction(name);
+    
+    // Create agent with basic configuration
+    const agent = agentCreator(
+      `Agent for ${input.name}`,
+      `You are an AI assistant handling: ${input.name}`,
+      null, // Let the agent creator handle the model
+      options
+    );
+
+    type Ret = ToolRet<R>;
+    let toolsObj: ToolSetMap<Ret> | undefined;
+
+    if (input.text_config.tools) {
+      toolsObj = {} as ToolSetMap<Ret>;
+
+      for (const [keyAny, def] of Object.entries(input.text_config.tools)) {
+        const key = keyAny as keyof Ret;
+
+        const impl = this.toolsRegistry?.has(key)
+          ? this.toolsRegistry.get(key)
+          : (_: any) =>
+              Promise.reject(new Error(`Tool ${String(key)} not registered`));
+
+        (toolsObj as any)[key] = createTool({
+          id: String(key),
+          description: def.description ?? "",
+          inputSchema: z.object(def.parameters as any),
+          execute: async ({ context }) => impl(context, options.toolContext),
+        }) as ToolWithExec<Ret[typeof key]>;
+      }
+    }
+
+    return {
+      agent,
+      messages: input.messages,
+      tools: toolsObj ?? ({} as ToolSetMap<Ret>),
+    };
+  }
+
+  adaptObject<K extends KeysWithKind<T, "object"> & string>(
+    input: ObjectConfig,
+    options: AdaptOptions,
+    metadata: PromptMetadata
+  ): MastraObjectParams<T[K]["output"]> {
+    const { model_name: name, ...settings } = input.object_config;
+    const agentCreator = this.agentRegistry.getAgentFunction(name);
+    
+    const agent = agentCreator(
+      `Object Agent for ${input.name}`,
+      `You are an AI assistant that returns structured output for: ${input.name}`,
+      null,
+      options
+    );
+
+    return {
+      agent,
+      messages: input.messages,
+      schema: z.object(input.object_config.schema as any),
+      ...(settings?.schema_name !== undefined
+        ? { schemaName: settings.schema_name }
+        : {}),
+      ...(settings?.schema_description !== undefined
+        ? { schemaDescription: settings.schema_description }
+        : {}),
+    };
+  }
+
+  adaptImage<K extends KeysWithKind<T, "image"> & string>(
+    input: ImageConfig,
+    options: AdaptOptions
+  ): MastraImageParams {
+    const { model_name: name, ...settings } = input.image_config;
+    const agentCreator = this.agentRegistry.getAgentFunction(name);
+    
+    const agent = agentCreator(
+      `Image Agent for ${input.name}`,
+      `You are an AI assistant that generates images for: ${input.name}`,
+      null,
+      options
+    );
+
+    return {
+      agent,
+      prompt: settings.prompt,
+      ...(settings?.num_images !== undefined ? { n: settings.num_images } : {}),
+      ...(settings?.size !== undefined
+        ? { size: settings.size as `${number}x${number}` }
+        : {}),
+      ...(settings?.aspect_ratio !== undefined
+        ? { aspectRatio: settings.aspect_ratio as `${number}:${number}` }
+        : {}),
+      ...(settings?.seed !== undefined ? { seed: settings.seed } : {}),
+    };
+  }
+
+  adaptSpeech<K extends KeysWithKind<T, "speech"> & string>(
+    input: SpeechConfig,
+    options: AdaptOptions
+  ): MastraSpeechParams {
+    const { model_name: name, ...settings } = input.speech_config;
+    const agentCreator = this.agentRegistry.getAgentFunction(name);
+    
+    const agent = agentCreator(
+      `Speech Agent for ${input.name}`,
+      `You are an AI assistant that handles speech for: ${input.name}`,
+      null,
+      options
+    );
+
+    return {
+      agent,
+      text: settings.text,
+      ...(settings?.voice !== undefined ? { voice: settings.voice } : {}),
+      ...(settings?.output_format !== undefined
+        ? { outputFormat: settings.output_format }
+        : {}),
+      ...(settings?.instructions !== undefined
+        ? { instructions: settings.instructions }
+        : {}),
+      ...(settings?.speed !== undefined ? { speed: settings.speed } : {}),
+    };
+  }
+}

--- a/packages/mastra-adapter/src/index.ts
+++ b/packages/mastra-adapter/src/index.ts
@@ -1,0 +1,69 @@
+import {
+  AdaptOptions,
+  AgentMark,
+  KeysWithKind,
+  Loader,
+  ObjectPrompt,
+  PromptFormatParams,
+  PromptShape,
+} from "@agentmark/agentmark-core";
+import {
+  MastraAdapter,
+  MastraAgentRegistry,
+  MastraObjectParams,
+  MastraToolRegistry,
+} from "./adapter";
+import type { Root } from "mdast";
+
+export interface MastraObjectPrompt<
+  T extends PromptShape<T>,
+  K extends KeysWithKind<T, "object"> & string,
+  Tools extends MastraToolRegistry<any, any>
+> extends ObjectPrompt<T, MastraAdapter<T, Tools>, K> {
+  format(
+    params: PromptFormatParams<T[K]["input"]>
+  ): Promise<MastraObjectParams<T[K]["output"]>>;
+
+  formatWithDataset(
+    options?: AdaptOptions
+  ): Promise<ReadableStream<MastraObjectParams<T[K]["output"]>>>;
+
+  formatWithTestProps(
+    options: AdaptOptions
+  ): Promise<MastraObjectParams<T[K]["output"]>>;
+}
+
+export interface MastraAgentMark<
+  T extends PromptShape<T>,
+  Tools extends MastraToolRegistry<any, any>
+> extends AgentMark<T, MastraAdapter<T, Tools>> {
+  loadObjectPrompt<K extends KeysWithKind<T, "object"> & string>(
+    pathOrPreloaded: K | Root,
+    options?: any
+  ): Promise<MastraObjectPrompt<T, K, Tools>>;
+}
+
+export function createAgentMarkClient<
+  D extends PromptShape<D> = any,
+  T extends MastraToolRegistry<any, any> = MastraToolRegistry<any, any>
+>(opts: {
+  loader?: Loader<D>;
+  agentRegistry: MastraAgentRegistry;
+  toolRegistry?: T;
+}): MastraAgentMark<D, T> {
+  const adapter = new MastraAdapter<D, T>(
+    opts.agentRegistry,
+    opts.toolRegistry
+  );
+
+  return new AgentMark<D, MastraAdapter<D, T>>({
+    loader: opts.loader,
+    adapter,
+  });
+}
+
+export {
+  MastraAdapter,
+  MastraAgentRegistry,
+  MastraToolRegistry,
+} from "./adapter";

--- a/packages/mastra-adapter/test/adapter.test.ts
+++ b/packages/mastra-adapter/test/adapter.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { MastraAdapter, MastraAgentRegistry, MastraToolRegistry } from "../src/adapter";
+
+describe("MastraAdapter", () => {
+  it("should create an adapter with the correct name", () => {
+    const agentRegistry = new MastraAgentRegistry();
+    const adapter = new MastraAdapter(agentRegistry);
+    
+    expect(adapter.__name).toBe("mastra");
+  });
+
+  it("should create agent registry with default creator", () => {
+    const defaultCreator = () => ({} as any);
+    const registry = new MastraAgentRegistry(defaultCreator);
+    
+    expect(registry).toBeInstanceOf(MastraAgentRegistry);
+  });
+
+  it("should create tool registry", () => {
+    const registry = new MastraToolRegistry();
+    
+    expect(registry).toBeInstanceOf(MastraToolRegistry);
+  });
+});

--- a/packages/mastra-adapter/tsconfig.json
+++ b/packages/mastra-adapter/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "module": "ESNext",
+    "target": "ES2019",
+    "lib": ["ESNext", "ES2017"],
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "preserve",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/__tests__/*"]
+}

--- a/packages/mastra-adapter/tsup.config.ts
+++ b/packages/mastra-adapter/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: [
+    "@agentmark/agentmark-core",
+    "@mastra/core",
+    "zod",
+    "react",
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@agentmark/mastra-adapter@workspace:packages/mastra-adapter":
+  version: 0.0.0-use.local
+  resolution: "@agentmark/mastra-adapter@workspace:packages/mastra-adapter"
+  dependencies:
+    "@agentmark/agentmark-core": "npm:^3.3.0"
+    "@types/node": "npm:^22.8.1"
+    "@types/react": "npm:^18"
+    cpy-cli: "npm:^5.0.0"
+    react: "npm:^18.3.1"
+    tsup: "npm:^8.3.5"
+    typescript: "npm:^5.6.2"
+    vitest: "npm:^3.0.8"
+    zod: "npm:^3.23.8"
+  peerDependencies:
+    "@agentmark/agentmark-core": ^3.2.0
+    "@mastra/core": ^1.0.0
+  languageName: unknown
+  linkType: soft
+
 "@agentmark/shared-utils@workspace:packages/shared-utils":
   version: 0.0.0-use.local
   resolution: "@agentmark/shared-utils@workspace:packages/shared-utils"


### PR DESCRIPTION
A new `@agentmark/mastra-adapter` package was added to integrate Mastra with AgentMark.

The new package includes:
*   `packages/mastra-adapter/src/adapter.ts`: Defines the core `MastraAdapter` class, implementing AgentMark's `Adapter<T>` interface. It includes `MastraAgentRegistry` for managing Mastra agents and `MastraToolRegistry` for handling tool execution.
*   `MastraAdapter` methods (`adaptText`, `adaptObject`, `adaptImage`, `adaptSpeech`) were implemented to map AgentMark configurations to Mastra's parameters, supporting text, structured object, image, and speech generation.
*   `packages/mastra-adapter/src/index.ts`: Exports the adapter components and a `createAgentMarkClient` factory function for easy client instantiation.
*   `packages/mastra-adapter/package.json`, `tsconfig.json`, `tsup.config.ts`: Configured for building, dependencies (`zod`), and peer dependencies (`@agentmark/agentmark-core`, `@mastra/core`).
*   `packages/mastra-adapter/README.md` and `CHANGELOG.md`: Provide documentation and version history.
*   `packages/mastra-adapter/test/adapter.test.ts`: Basic unit tests were added to verify core functionalities.

The adapter mirrors the architectural patterns of the existing Vercel AI v4 adapter, ensuring consistency and seamless integration with AgentMark's prompt system and Mastra's agent, tool, and workflow capabilities.