### PR TITLE
Fix file path resolution in run-prompt command

### DIFF
--- a/.changeset/sharp-grapes-flow.md
+++ b/.changeset/sharp-grapes-flow.md
@@ -1,0 +1,5 @@
+---
+"@agentmark/cli": patch
+---
+
+Fix: run-prompt resolves relative path

--- a/packages/cli/src/commands/run-prompt.ts
+++ b/packages/cli/src/commands/run-prompt.ts
@@ -520,24 +520,27 @@ const executeSpeechDatasetPrompt = async (inputs: ReadableStream<any>) => {
 };
 
 const runPrompt = async (filepath: string, options: RunPromptOptions) => {
+  // Resolve the file path relative to the current working directory
+  const resolvedFilepath = path.resolve(filepath);
+  
   // Validate file exists and is an .mdx file
-  if (!fs.existsSync(filepath)) {
-    throw new Error(`File not found: ${filepath}`);
+  if (!fs.existsSync(resolvedFilepath)) {
+    throw new Error(`File not found: ${resolvedFilepath}`);
   }
   
-  if (!filepath.endsWith('.mdx')) {
+  if (!resolvedFilepath.endsWith('.mdx')) {
     throw new Error('File must be an .mdx file');
   }
 
   // Get the directory containing the prompt file
-  const fileDirectory = path.dirname(path.resolve(filepath));
+  const fileDirectory = path.dirname(resolvedFilepath);
   const fileLoader = new FileLoader(fileDirectory);
 
   // Dynamic import for ESM module
   const { getFrontMatter, load } = await import("@agentmark/templatedx");
   
   // Load and parse the prompt file
-  let ast: Root = await load(filepath);
+  let ast: Root = await load(resolvedFilepath);
   const frontmatter: any = getFrontMatter(ast);
 
   // Handle old format if needed (from VSCode extension logic)


### PR DESCRIPTION
## Description

Allows `run-prompt` to be resolved/run via relative path.

Fixes # https://github.com/agentmark-ai/agentmark/issues/286

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
