### PR TITLE
LlamaIndex Framework Adapter for AgentMark

### DIFF
--- a/apps/LlamaIndex-Demo/Agent.ts
+++ b/apps/LlamaIndex-Demo/Agent.ts
@@ -1,0 +1,58 @@
+import { config } from "dotenv";
+import { gemini, GEMINI_MODEL } from "@llamaindex/google";
+import { FileLoader } from "@agentmark/agentmark-core";
+import { agent } from "@llamaindex/workflow";
+import {
+  createAgentMarkClient,
+  LlamaIndexModelRegistry,
+  LlamaIndexToolRegistry,
+} from "@agentmark/llamaindex-adapter";
+import AgentmarkTypes from "./test";
+
+config();
+const calculateTool = async (input: { expression: string }) => {
+  // Note: This is a simple example and eval should not be used in production
+  const result = eval(input.expression);
+  return { result };
+};
+
+async function main() {
+  // Step 1: Register all valid models
+  const modelRegistry = new LlamaIndexModelRegistry();
+  const validModels = Object.values(GEMINI_MODEL);
+  modelRegistry.registerModels(validModels, (name) =>
+    gemini({
+      apiKey: process.env.GOOGLE_API_KEY!,
+      model: name as GEMINI_MODEL,
+    })
+  );
+
+  const toolRegistry = new LlamaIndexToolRegistry();
+  toolRegistry.register("calculate", calculateTool);
+
+  // Step 2: Create AgentMark client with proper typing
+  const amClient = createAgentMarkClient<AgentmarkTypes>({
+    loader: new FileLoader("./"),
+    modelRegistry,
+    toolRegistry,
+  });
+
+  const prompt = await amClient.loadTextPrompt("example.prompt.mdx");
+  const agentInput = await prompt.formatAgent({
+    props: {
+      userType: "admin",
+      num: 3,
+    },
+  });
+  console.log("Agent Input:", agentInput);
+  const userInput = await agentInput.formatGenerateText({
+    props: {},
+  });
+  console.log("User Input:", userInput);
+  const myAgent = agent(agentInput);
+
+  const response = await myAgent.run(userInput);
+  console.log("AI Response:", response.data.message);
+}
+
+main();

--- a/apps/LlamaIndex-Demo/example.prompt.mdx
+++ b/apps/LlamaIndex-Demo/example.prompt.mdx
@@ -1,0 +1,22 @@
+---
+name: calculator
+text_config:
+  model_name: gemini-1.5-flash-002
+  tools:
+    calculate:
+      description: Performs basic arithmetic calculations
+      parameters:
+        type: object
+        properties:
+          expression:
+            type: string
+            description: The mathematical expression to evaluate
+        required: ["expression"]
+---
+
+<System>
+  You are a math tutor that can perform calculations. Use the calculate tool
+  when you need to compute something.
+</System>
+
+<User>What's 235 * 18 plus 42?</User>

--- a/apps/LlamaIndex-Demo/package.json
+++ b/apps/LlamaIndex-Demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "llama-index-demo",
+  "version": "0.0.11",
+  "private": true,
+  "dependencies": {
+    "@agentmark/agentmark-core": "workspace:*",
+    "@agentmark/llamaindex-adapter": "workspace:^",
+    "@llamaindex/google": "^0.3.18",
+    "@llamaindex/workflow": "^1.1.20",
+    "dotenv": "^17.2.1"
+  }
+}

--- a/apps/LlamaIndex-Demo/test.ts
+++ b/apps/LlamaIndex-Demo/test.ts
@@ -1,0 +1,12 @@
+type Example = {
+  kind: "text";
+  input: {
+    userType: string;
+    num: number;
+  };
+  output: {};
+};
+
+export default interface AgentmarkTypes {
+  "example.prompt.mdx": Example;
+}

--- a/packages/LlamaIndex-Adapter/package.json
+++ b/packages/LlamaIndex-Adapter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@agentmark/llamaindex-adapter",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@agentmark/agentmark-core": "workspace:^",
+    "@llamaindex/google": "^0.3.18",
+    "llamaindex": "^0.11.26"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.0.0"
+  },
+  "keywords": [],
+  "author": "Muhammad Haris",
+  "license": "AgentMark"
+}

--- a/packages/LlamaIndex-Adapter/src/adapter.ts
+++ b/packages/LlamaIndex-Adapter/src/adapter.ts
@@ -1,0 +1,310 @@
+import {
+  AgentMark,
+  type PromptShape,
+  type Adapter,
+  type Loader,
+  type KeysWithKind,
+  TextPrompt,
+  type AdaptOptions,
+  type PromptMetadata,
+  type TextConfig,
+  type ObjectConfig,
+  type ImageConfig,
+  type SpeechConfig,
+  type RichChatMessage,
+} from "@agentmark/agentmark-core";
+import { LlamaIndexToolRegistry, ToolMetadata, Merge } from "./tool-registry";
+import type { Root } from "mdast";
+import { Settings as LlamaSettings } from "llamaindex";
+import { LlamaIndexModelRegistry } from "./model-registry";
+
+interface MessageContent {
+  type: string;
+  text?: string;
+  [key: string]: any;
+}
+
+// Helper type to ensure exact properties only
+type ExactProps<T, U> = U & {
+  [K in Exclude<keyof U, keyof T>]: never;
+};
+
+// Helper type for message props that prevents both duplicate and invalid props
+type MessageProps<TInput, TUsed> = keyof Omit<TInput, keyof TUsed> extends never
+  ? { [K in keyof TInput]?: never }
+  : { [K in keyof Omit<TInput, keyof TUsed>]: TInput[K] } & {
+      [K in keyof TUsed]?: never;
+    };
+
+export class LlamaIndexAdapter<
+  T extends PromptShape<T>,
+  R extends LlamaIndexToolRegistry<any, any> = LlamaIndexToolRegistry<any, any>
+> implements Adapter<T>
+{
+  readonly __dict!: T;
+  readonly __name = "llama-index-adapter";
+
+  private readonly toolsRegistry: R | undefined;
+
+  constructor(toolRegistry?: R) {
+    this.toolsRegistry = toolRegistry;
+  }
+
+  adaptTextForAgent<
+    K extends KeysWithKind<T, "text"> & string,
+    UsedProps extends Partial<T[K]["input"]>
+  >(
+    input: TextConfig,
+    propsWrapper: { props: ExactProps<T[K]["input"], UsedProps> },
+    metadata?: PromptMetadata,
+    options?: AdaptOptions
+  ) {
+    const extracted = {
+      model: "",
+      systemPrompt: "",
+      maxCalls: 1,
+      tools: [] as Array<{
+        name: string;
+        description: string;
+        parameters: any;
+        call: (
+          args: any,
+          toolContext?: Record<string, any>
+        ) => any | Promise<any>;
+        metadata: ToolMetadata;
+      }>,
+    };
+
+    // Extract model configuration
+    extracted.model = input.text_config?.model_name || "";
+    extracted.maxCalls = input.text_config?.max_calls || 1;
+    // Extract system message
+    const systemMessage = input.messages.find(
+      (msg: RichChatMessage) => msg.role === "system"
+    );
+
+    if (systemMessage) {
+      extracted.systemPrompt = (systemMessage?.content as string) || "";
+    } else {
+      console.warn("No system message found in messages:", input.messages);
+    }
+
+    // Process tools from the .prompt.mdx frontmatter
+    if (
+      input.text_config.tools &&
+      typeof input.text_config.tools === "object"
+    ) {
+      for (const [toolName, toolDef] of Object.entries(
+        input.text_config.tools
+      )) {
+        const toolImpl = this.toolsRegistry?.get(toolName);
+        const metadata: ToolMetadata = {
+          name: toolName,
+          description: (toolDef as any).description ?? `Tool: ${toolName}`,
+          parameters: (toolDef as any).parameters || {},
+        };
+
+        if (toolImpl) {
+          extracted.tools.push({
+            name: toolName,
+            description: metadata.description,
+            parameters: metadata.parameters,
+            call: async (args: any) => {
+              try {
+                return await toolImpl(args, options?.toolContext);
+              } catch (error) {
+                console.error(`Error executing tool ${toolName}:`, error);
+                throw error;
+              }
+            },
+            metadata,
+          });
+        } else {
+          console.warn(
+            `Tool ${toolName} is defined in prompt but not registered in tool registry`
+          );
+
+          extracted.tools.push({
+            name: toolName,
+            description: metadata.description,
+            parameters: metadata.parameters,
+            call: (_: any) => {
+              throw new Error(
+                `Tool ${toolName} not registered in tool registry. Available tools: ${
+                  this.toolsRegistry?.getToolNames().join(", ") || "none"
+                }`
+              );
+            },
+            metadata,
+          });
+        }
+      }
+    }
+    return extracted;
+  }
+
+  adaptTextForGenerate(input: TextConfig) {
+    const userMessage = input.messages.find(
+      (msg: RichChatMessage) => msg.role === "user"
+    );
+
+    let userPrompt = "";
+    if (userMessage) {
+      if (typeof userMessage.content === "string") {
+        userPrompt = userMessage.content;
+      } else if (Array.isArray(userMessage.content)) {
+        userPrompt = userMessage.content
+          .filter((item: MessageContent) => item.type === "text")
+          .map((item: MessageContent) => item.text || "")
+          .join(" ");
+      }
+    } else {
+      console.warn("No user message found in messages");
+    }
+
+    return userPrompt;
+  }
+
+  adaptText<K extends KeysWithKind<T, "text"> & string>(
+    input: TextConfig,
+    options: AdaptOptions,
+    metadata: PromptMetadata
+  ): any {
+    return input;
+  }
+
+  adaptObject<K extends KeysWithKind<T, "object"> & string>(
+    input: ObjectConfig,
+    options: AdaptOptions,
+    metadata: PromptMetadata
+  ): any {
+    return "adaptObject is not implemented - use formatAgent instead";
+  }
+
+  adaptImage<K extends KeysWithKind<T, "image"> & string>(
+    input: ImageConfig,
+    options: AdaptOptions
+  ): any {
+    return "adaptImage is not implemented - use formatAgent instead";
+  }
+
+  adaptSpeech<K extends KeysWithKind<T, "speech"> & string>(
+    input: SpeechConfig,
+    options: AdaptOptions
+  ): any {
+    return "adaptSpeech is not implemented - use formatAgent instead";
+  }
+}
+
+export class LlamaIndexTextPrompt<
+  T extends PromptShape<T>,
+  K extends KeysWithKind<T, "text"> & string,
+  R extends LlamaIndexToolRegistry<any, any> = LlamaIndexToolRegistry<any, any>
+> extends TextPrompt<T, LlamaIndexAdapter<T, R>, K> {
+  modelRegistry: LlamaIndexModelRegistry;
+  adapter: LlamaIndexAdapter<T, R>;
+
+  constructor(
+    content: unknown,
+    templateEngine: any,
+    adapter: LlamaIndexAdapter<T, R>,
+    path: K | undefined,
+    testSettings: any,
+    loader: Loader<T> | undefined,
+    modelRegistry: LlamaIndexModelRegistry
+  ) {
+    super(content, templateEngine, adapter, path, testSettings, loader);
+    this.modelRegistry = modelRegistry;
+    this.adapter = adapter;
+  }
+
+  async formatAgent<UsedProps extends Partial<T[K]["input"]>>(
+    agentPropsWrapper: { props: ExactProps<T[K]["input"], UsedProps> },
+    options?: AdaptOptions
+  ) {
+    const agentProps = agentPropsWrapper.props;
+
+    const placeholderProps = {} as T[K]["input"];
+    const partialProps = { ...placeholderProps, ...agentProps };
+
+    const formattedInput = await this.compile(partialProps);
+
+    const agentConfig = this.adapter.adaptTextForAgent(
+      formattedInput,
+      agentPropsWrapper,
+      undefined,
+      options
+    );
+
+    const llm = this.modelRegistry.getModel(agentConfig.model);
+    LlamaSettings.llm = llm;
+
+    return {
+      ...agentConfig,
+      formatGenerateText: async (
+        messagePropsWrapper: {
+          props: MessageProps<T[K]["input"], UsedProps>;
+        } = { props: {} as MessageProps<T[K]["input"], UsedProps> }
+      ) => {
+        const messageProps = messagePropsWrapper.props;
+
+        const allProps = {
+          ...agentProps,
+          ...messageProps,
+        } as T[K]["input"];
+
+        const finalFormattedInput = await this.compile(allProps);
+        return this.adapter.adaptTextForGenerate(finalFormattedInput);
+      },
+    };
+  }
+}
+
+export class LlamaAgentmark<
+  T extends PromptShape<T>,
+  R extends LlamaIndexToolRegistry<any, any> = LlamaIndexToolRegistry<any, any>
+> extends AgentMark<T, LlamaIndexAdapter<T, R>> {
+  modelRegistry: LlamaIndexModelRegistry;
+  adapter: LlamaIndexAdapter<T, R>;
+  toolRegistry?: R;
+
+  constructor(opts: {
+    loader?: Loader<T>;
+    modelRegistry: LlamaIndexModelRegistry;
+    toolRegistry?: R;
+  }) {
+    const adapter = new LlamaIndexAdapter<T, R>(opts.toolRegistry);
+    super({ loader: opts.loader, adapter });
+    this.modelRegistry = opts.modelRegistry;
+    this.adapter = adapter;
+    this.toolRegistry = opts.toolRegistry;
+  }
+
+  override async loadTextPrompt<K extends KeysWithKind<T, "text"> & string>(
+    pathOrPreloaded: K | Root,
+    options?: any
+  ): Promise<LlamaIndexTextPrompt<T, K, R>> {
+    let content: unknown;
+    const pathProvided = typeof pathOrPreloaded === "string";
+
+    if (pathProvided && this.loader) {
+      content = await this.loader.load(pathOrPreloaded, "text", options);
+    } else {
+      content = pathOrPreloaded;
+    }
+
+    const textConfig: TextConfig = await this.templateEngine.compile({
+      template: content,
+    });
+
+    return new LlamaIndexTextPrompt<T, K, R>(
+      content,
+      this.templateEngine,
+      this.adapter,
+      pathProvided ? pathOrPreloaded : undefined,
+      textConfig.test_settings,
+      this.loader,
+      this.modelRegistry
+    );
+  }
+}

--- a/packages/LlamaIndex-Adapter/src/index.ts
+++ b/packages/LlamaIndex-Adapter/src/index.ts
@@ -1,0 +1,20 @@
+import type { PromptShape, Loader } from "@agentmark/agentmark-core";
+import { AgentMark } from "@agentmark/agentmark-core";
+import { LlamaIndexAdapter, LlamaAgentmark } from "./adapter";
+import { LlamaIndexModelRegistry } from "./model-registry";
+import { LlamaIndexToolRegistry } from "./tool-registry";
+export function createAgentMarkClient<D extends PromptShape<D> = any>(opts: {
+  loader?: Loader<D>;
+  modelRegistry: LlamaIndexModelRegistry;
+  toolRegistry?: LlamaIndexToolRegistry; // Use proper type
+}): LlamaAgentmark<D> {
+  return new LlamaAgentmark<D>({
+    loader: opts.loader,
+    modelRegistry: opts.modelRegistry,
+    toolRegistry: opts.toolRegistry, // Pass through tool registry
+  });
+}
+
+export { LlamaIndexAdapter } from "./adapter";
+export { LlamaIndexModelRegistry } from "./model-registry";
+export { LlamaIndexToolRegistry } from "./tool-registry";

--- a/packages/LlamaIndex-Adapter/src/model-registry.ts
+++ b/packages/LlamaIndex-Adapter/src/model-registry.ts
@@ -1,0 +1,19 @@
+import { GEMINI_MODEL } from "@llamaindex/google";
+
+type ModelFactory = (name: string) => any;
+
+export class LlamaIndexModelRegistry {
+  private models: Record<string, ModelFactory> = {};
+
+  registerModels(modelNames: string[], factory: ModelFactory) {
+    for (const name of modelNames) {
+      this.models[name] = factory;
+    }
+  }
+
+  getModel(name: string) {
+    const factory = this.models[name];
+    if (!factory) throw new Error(`Model "${name}" not registered.`);
+    return factory(name as GEMINI_MODEL);
+  }
+}

--- a/packages/LlamaIndex-Adapter/src/tool-registry.ts
+++ b/packages/LlamaIndex-Adapter/src/tool-registry.ts
@@ -1,0 +1,67 @@
+export type Merge<A, B> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+    ? A[K]
+    : never;
+};
+
+export type ToolMetadata<
+  Parameters extends Record<string, unknown> = Record<string, unknown>
+> = {
+  name: string;
+  description: string;
+  parameters?: Parameters;
+};
+
+export class LlamaIndexToolRegistry<
+  TD extends Record<string, { args: any }> = Record<string, { args: any }>,
+  RM extends Partial<Record<keyof TD, any>> = {}
+> {
+  private map: Map<
+    string,
+    (args: any, toolContext?: Record<string, any>) => any
+  > = new Map();
+
+  register<K extends string, R>(
+    name: K,
+    fn: (args: any, toolContext?: Record<string, any>) => R | Promise<R>
+  ): LlamaIndexToolRegistry<
+    TD & { [P in K]: { args: any } },
+    Merge<RM, { [P in K]: R }>
+  > {
+    this.map.set(name, fn);
+    return this as any;
+  }
+
+  get(name: string) {
+    return this.map.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.map.has(name);
+  }
+
+  getRegisteredTools(): Array<{
+    name: string;
+    implementation: (args: any, toolContext?: Record<string, any>) => any;
+  }> {
+    const tools: Array<{
+      name: string;
+      implementation: (args: any, toolContext?: Record<string, any>) => any;
+    }> = [];
+
+    for (const [name, impl] of this.map.entries()) {
+      tools.push({
+        name,
+        implementation: impl,
+      });
+    }
+
+    return tools;
+  }
+
+  getToolNames(): string[] {
+    return Array.from(this.map.keys());
+  }
+}

--- a/packages/LlamaIndex-Adapter/tsconfig.json
+++ b/packages/LlamaIndex-Adapter/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "module": "ESNext",
+    "target": "ES2019",
+    "lib": ["ESNext"],
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "preserve",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/__tests__/*"]
+}

--- a/packages/LlamaIndex-Adapter/tsup.config.ts
+++ b/packages/LlamaIndex-Adapter/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  target: 'es2019',
+  treeshake: true,
+  outExtension({ format }) {
+    return {
+      js: format === 'cjs' ? '.cjs' : '.js'
+    }
+  },
+  esbuildOptions(options) {
+    options.mainFields = ['module', 'main']
+    options.platform = 'node'
+  },
+});

--- a/packages/agentmark-core/src/index.ts
+++ b/packages/agentmark-core/src/index.ts
@@ -3,7 +3,7 @@ export { DefaultAdapter } from "./adapters/default";
 export { FileLoader } from "./loaders/file";
 export { TemplateDXTemplateEngine } from "./template_engines/templatedx";
 export { getTemplateDXInstance } from "./template_engines/templatedx-instances";
-export { ObjectPrompt } from "./prompts";
+export { ObjectPrompt, ImagePrompt, SpeechPrompt, TextPrompt } from "./prompts";
 export type { PromptFormatParams } from "./prompts";
 export type { AgentMarkOptions } from "./agentmark";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@agentmark/agentmark-core@npm:*, @agentmark/agentmark-core@npm:^3.2.0, @agentmark/agentmark-core@npm:^3.3.1, @agentmark/agentmark-core@npm:^3.3.2, @agentmark/agentmark-core@npm:^3.3.3, @agentmark/agentmark-core@workspace:*, @agentmark/agentmark-core@workspace:packages/agentmark-core":
+"@agentmark/agentmark-core@npm:*, @agentmark/agentmark-core@npm:^3.2.0, @agentmark/agentmark-core@npm:^3.3.1, @agentmark/agentmark-core@npm:^3.3.2, @agentmark/agentmark-core@npm:^3.3.3, @agentmark/agentmark-core@workspace:*, @agentmark/agentmark-core@workspace:^, @agentmark/agentmark-core@workspace:packages/agentmark-core":
   version: 0.0.0-use.local
   resolution: "@agentmark/agentmark-core@workspace:packages/agentmark-core"
   dependencies:
@@ -75,6 +75,19 @@ __metadata:
   peerDependencies:
     "@agentmark/agentmark-core": ^3.2.0
     ai: ^4.0.0
+  languageName: unknown
+  linkType: soft
+
+"@agentmark/llamaindex-adapter@workspace:^, @agentmark/llamaindex-adapter@workspace:packages/LlamaIndex-Adapter":
+  version: 0.0.0-use.local
+  resolution: "@agentmark/llamaindex-adapter@workspace:packages/LlamaIndex-Adapter"
+  dependencies:
+    "@agentmark/agentmark-core": "workspace:^"
+    "@llamaindex/google": "npm:^0.3.18"
+    llamaindex: "npm:^0.11.26"
+    ts-node: "npm:^10.0.0"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -262,6 +275,38 @@ __metadata:
     "@types/json-schema": "npm:^7.0.15"
     js-yaml: "npm:^4.1.0"
   checksum: 10c0/5745813b3d964279f387677b7a903ba6634cdeaf879ff3a331a694392cbc923763f398506df190be114f2574b8b570baab3e367c2194bb35f50147ff6cf27d7a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6c48701f8336341bb104dfde3d0050c89c288051f6b5e9bdfeb8091cf3ffc86efcd5c9e6ff2a4a134406b019c07aca9db608128f8d9267c952578a3108db9fd1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0362d4c197b1fd64b423966945130207d1fe23e1bb2878a18e361f7743c8d339dad3f8729895a29aa34fff6a86c65f281cf5167c4bf253f21627ae80b6dd2951
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
+  version: 3.862.0
+  resolution: "@aws-sdk/types@npm:3.862.0"
+  dependencies:
+    "@smithy/types": "npm:^4.3.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d8e13eadde27c29e39d8effa861a3dc8ef43fba6ecb9772e3461619a76897873c8d4355be89aa5090294d1f17e1a6697834f0bbf6a7f73902a77fe00b1fbe5c2
   languageName: node
   linkType: hard
 
@@ -916,6 +961,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.9"
+  checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -1193,6 +1247,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google/genai@npm:^1.7.0":
+  version: 1.13.0
+  resolution: "@google/genai@npm:1.13.0"
+  dependencies:
+    google-auth-library: "npm:^9.14.2"
+    ws: "npm:^8.18.0"
+  peerDependencies:
+    "@modelcontextprotocol/sdk": ^1.11.0
+  peerDependenciesMeta:
+    "@modelcontextprotocol/sdk":
+      optional: true
+  checksum: 10c0/0277ba402314984711c01108ce46c76c825d5e6246039852a527d16f4e43225c1166417da6e6138f94952268c24cda70191d892e20367f1da39037203eea9dd7
+  languageName: node
+  linkType: hard
+
 "@grpc/grpc-js@npm:^1.7.1":
   version: 1.13.4
   resolution: "@grpc/grpc-js@npm:1.13.4"
@@ -1335,7 +1404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
@@ -1363,6 +1432,16 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.0.3"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+  checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -1396,6 +1475,119 @@ __metadata:
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
   checksum: 10c0/5ba1a263d312bb486cd2168e8c137a4e9cec1f883bcf5e112f8e3096b9e880cdf8c1bc977029023b8e1bcc6b2a0420fdaecd19e42c7d2d538b3499bd78ad5863
+  languageName: node
+  linkType: hard
+
+"@llamaindex/cloud@npm:4.1.1":
+  version: 4.1.1
+  resolution: "@llamaindex/cloud@npm:4.1.1"
+  dependencies:
+    p-retry: "npm:^6.2.1"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    "@llama-flow/core": ^0.4.1
+    "@llamaindex/core": 0.6.19
+    "@llamaindex/env": 0.1.30
+  checksum: 10c0/699cbabbc03f37130ba53006165535220b56bff402b28b20e8cdbbfe8416ec3619b313b8b6be9fd1f864609d1dd0e2c7be63d42506d323aaaf5466df0080c86e
+  languageName: node
+  linkType: hard
+
+"@llamaindex/core@npm:0.6.19":
+  version: 0.6.19
+  resolution: "@llamaindex/core@npm:0.6.19"
+  dependencies:
+    "@llamaindex/env": "npm:0.1.30"
+    "@types/node": "npm:^24.0.13"
+    magic-bytes.js: "npm:^1.10.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.24.6"
+  checksum: 10c0/092f6f1f0576bd1d7748a11d5efd7dd7d99e05230007ef2a0a57110769301a217f281f9eb82dbe68591bb6d447cb74d13863227ed335a91c0a31754fd847abac
+  languageName: node
+  linkType: hard
+
+"@llamaindex/env@npm:0.1.30":
+  version: 0.1.30
+  resolution: "@llamaindex/env@npm:0.1.30"
+  dependencies:
+    "@aws-crypto/sha256-js": "npm:^5.2.0"
+    js-tiktoken: "npm:^1.0.12"
+    pathe: "npm:^1.1.2"
+  peerDependencies:
+    "@huggingface/transformers": ^3.5.0
+    gpt-tokenizer: ^2.5.0
+  peerDependenciesMeta:
+    "@huggingface/transformers":
+      optional: true
+    gpt-tokenizer:
+      optional: true
+  checksum: 10c0/1fde60329c56488641fbbaaebd0f1bd3895b443631e4c87902dace022a6432754d93a10fb51dae83530fa79d111dc16b0149db290b719e7b0a1fbdb587ac53b5
+  languageName: node
+  linkType: hard
+
+"@llamaindex/google@npm:^0.3.18":
+  version: 0.3.18
+  resolution: "@llamaindex/google@npm:0.3.18"
+  dependencies:
+    "@google/genai": "npm:^1.7.0"
+  peerDependencies:
+    "@llamaindex/core": 0.6.19
+    "@llamaindex/env": 0.1.30
+  checksum: 10c0/448c3fc168a09a917c3172224ee4f11efaaf4ba21b07d1ae59271dde59d826ed0729f0b4ec7932d06092ba135c6a52b4a3405209201ab7267566ca81eec2d9f3
+  languageName: node
+  linkType: hard
+
+"@llamaindex/node-parser@npm:2.0.19":
+  version: 2.0.19
+  resolution: "@llamaindex/node-parser@npm:2.0.19"
+  dependencies:
+    html-to-text: "npm:^9.0.5"
+  peerDependencies:
+    "@llamaindex/core": 0.6.19
+    "@llamaindex/env": 0.1.30
+    tree-sitter: ^0.22.0
+    web-tree-sitter: ^0.24.3
+  checksum: 10c0/8d5b9afd8eca421f33b28fe86d1337f1f4bdca13e4493a4dc71eb6743e4a519442c68a3d5ce3ea7b1e5514d26d81a3877a1a2607a9773f7b6fe33f551d746ed4
+  languageName: node
+  linkType: hard
+
+"@llamaindex/workflow-core@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "@llamaindex/workflow-core@npm:1.2.0"
+  peerDependencies:
+    "@modelcontextprotocol/sdk": ^1.7.0
+    hono: ^4.7.4
+    next: ^15.2.2
+    p-retry: ^6.2.1
+    rxjs: ^7.8.2
+    zod: ^3.24.2
+  peerDependenciesMeta:
+    "@modelcontextprotocol/sdk":
+      optional: true
+    hono:
+      optional: true
+    next:
+      optional: true
+    p-retry:
+      optional: true
+    rxjs:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10c0/160bceccd27c056560990bd8fa7e8dceb58ecade927f7dde7d809c1619850baae821bc0a0a61c4f8ff7ea2fda5761f4ae254208404ee6411660715b0db934093
+  languageName: node
+  linkType: hard
+
+"@llamaindex/workflow@npm:1.1.20, @llamaindex/workflow@npm:^1.1.20":
+  version: 1.1.20
+  resolution: "@llamaindex/workflow@npm:1.1.20"
+  dependencies:
+    "@llamaindex/workflow-core": "npm:^1.0.0"
+  peerDependencies:
+    "@llamaindex/core": 0.6.19
+    "@llamaindex/env": 0.1.30
+    zod: ^3.25.67
+    zod-to-json-schema: ^3.24.6
+  checksum: 10c0/b84f3f9a95100d9fd02eb483f9409be6ba5d5c9106df2021bd97c126fe2dd60c17fb07338ac32f987ffdc26db06c5ac441e78d1a840b7a656621ed0a0fe1170b
   languageName: node
   linkType: hard
 
@@ -2186,6 +2378,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@selderee/plugin-htmlparser2@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@selderee/plugin-htmlparser2@npm:0.11.0"
+  dependencies:
+    domhandler: "npm:^5.0.3"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/e938ba9aeb31a9cf30dcb2977ef41685c598bf744bedc88c57aa9e8b7e71b51781695cf99c08aac50773fd7714eba670bd2a079e46db0788abe40c6d220084eb
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -2197,6 +2399,44 @@ __metadata:
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: 10c0/69ee906f3125fb2c6bb6ec5cdd84e8827d93b49b3892bce8b62267116cc7e197b5cccf20c160a1d32c26014ecd14470a72a5e3ee37a58f1d6dadc0db1ccf3894
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f2523cd8cc4538131e408eb31664983fecb0c8724956788b015aaf3ab85a0c976b50f4f09b176f1ed7bbe79f3edf80743be7a80a11f22cd9ce1285d77161aaf
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@smithy/types@npm:4.3.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/120c5d38f6362c86e6493cce3b9ca9902cd986dab773b39664ff6a95b787c45481f1b1d230f45a6f5ad0c045fb690dc96b51b9ca7b5e9487714a652ed98231f6
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/223d6a508b52ff236eea01cddc062b7652d859dd01d457a4e50365af3de1e24a05f756e19433f6ccf1538544076b4215469e21a4ea83dc1d58d829725b0dbc5a
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e18840c58cc507ca57fdd624302aefd13337ee982754c9aa688463ffcae598c08461e8620e9852a424d662ffa948fc64919e852508028d09e89ced459bd506ab
   languageName: node
   linkType: hard
 
@@ -2249,6 +2489,34 @@ __metadata:
   dependencies:
     "@textlint/ast-node-types": "npm:^14.7.2"
   checksum: 10c0/87766f7fc901950fd98c3aef324447b547b986ae9a7e785e3cc47d96f9fdf68f556a63619d3d2e61b0a48867faf973894c647c64cc50fd1586eeb6e480952b79
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node10@npm:1.0.11"
+  checksum: 10c0/28a0710e5d039e0de484bdf85fee883bfd3f6a8980601f4d44066b0a6bcd821d31c4e231d1117731c4e24268bd4cf2a788a6787c12fc7f8d11014c07d582783c
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 10c0/dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 10c0/67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "@tsconfig/node16@npm:1.0.4"
+  checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
   languageName: node
   linkType: hard
 
@@ -2502,6 +2770,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.0.13":
+  version: 24.2.0
+  resolution: "@types/node@npm:24.2.0"
+  dependencies:
+    undici-types: "npm:~7.10.0"
+  checksum: 10c0/0b55af4d7b37fea47bbeffffaff908462fa19ea9b1a18f92d9ed6d8415d97971b254f8cb3f629cd238916e94711fdb6ac939aa750cb353dfd6df6c0339435740
+  languageName: node
+  linkType: hard
+
 "@types/normalize-package-data@npm:^2.4.1":
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
@@ -2547,6 +2824,13 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/d5d77d5329ed6cf6d2f77d778bfc128e2a4d1b0e30d8eebd5e295c207615842abaff57813cd39be5939a9c4aecacd3771f4e7a8d874d5a8002ff18809f237c19
+  languageName: node
+  linkType: hard
+
+"@types/retry@npm:0.12.2":
+  version: 0.12.2
+  resolution: "@types/retry@npm:0.12.2"
+  checksum: 10c0/07481551a988cc90b423351919928b9ddcd14e3f5591cac3ab950851bb20646e55a10e89141b38bc3093d2056d4df73700b22ff2612976ac86a6367862381884
   languageName: node
   linkType: hard
 
@@ -3240,12 +3524,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/76537ac5fb2c37a64560feaf3342023dadc086c46da57da363e64c6148dc21b57d49ace26f949e225063acb6fb441eabffd89f7a3066de5ad37ab3e328927c62
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.0.0, acorn@npm:^8.14.0":
   version: 8.14.1
   resolution: "acorn@npm:8.14.1"
   bin:
     acorn: bin/acorn
   checksum: 10c0/dbd36c1ed1d2fa3550140000371fcf721578095b18777b85a79df231ca093b08edc6858d75d6e48c73e431c174dcf9214edbd7e6fa5911b93bd8abfa54e47123
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.0, acorn@npm:^8.4.1":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
   languageName: node
   linkType: hard
 
@@ -3470,6 +3772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
@@ -3552,7 +3861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.3.0, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -3565,6 +3874,13 @@ __metadata:
   dependencies:
     is-windows: "npm:^1.0.0"
   checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.0":
+  version: 9.3.1
+  resolution: "bignumber.js@npm:9.3.1"
+  checksum: 10c0/61342ba5fe1c10887f0ecf5be02ff6709271481aff48631f86b4d37d55a99b87ce441cfd54df3d16d10ee07ceab7e272fc0be430c657ffafbbbf7b7d631efb75
   languageName: node
   linkType: hard
 
@@ -4274,6 +4590,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -4379,6 +4702,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deepmerge@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
 "default-browser-id@npm:^5.0.0":
   version: 5.0.0
   resolution: "default-browser-id@npm:5.0.0"
@@ -4468,6 +4798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
 "diff@npm:^5.2.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
@@ -4529,6 +4866,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^17.2.1":
+  version: 17.2.1
+  resolution: "dotenv@npm:17.2.1"
+  checksum: 10c0/918dd2f9d8b8f86b0afabad9534793d51de3718c437f9e7b6525628cf68c1d4ae768cc37a5afff38c066f58a8ecf549f4ac6cd5617485bd328e826112cc2650a
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -4547,7 +4891,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ecdsa-sig-formatter@npm:1.0.11":
+"ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
   version: 1.0.11
   resolution: "ecdsa-sig-formatter@npm:1.0.11"
   dependencies:
@@ -5126,7 +5470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.0":
+"extend@npm:^3.0.0, extend@npm:^3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
@@ -5474,6 +5818,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^6.0.0, gaxios@npm:^6.1.1":
+  version: 6.7.1
+  resolution: "gaxios@npm:6.7.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    is-stream: "npm:^2.0.0"
+    node-fetch: "npm:^2.6.9"
+    uuid: "npm:^9.0.1"
+  checksum: 10c0/53e92088470661c5bc493a1de29d05aff58b1f0009ec5e7903f730f892c3642a93e264e61904383741ccbab1ce6e519f12a985bba91e13527678b32ee6d7d3fd
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "gcp-metadata@npm:6.1.1"
+  dependencies:
+    gaxios: "npm:^6.1.1"
+    google-logging-utils: "npm:^0.0.2"
+    json-bigint: "npm:^1.0.0"
+  checksum: 10c0/71f6ad4800aa622c246ceec3955014c0c78cdcfe025971f9558b9379f4019f5e65772763428ee8c3244fa81b8631977316eaa71a823493f82e5c44d7259ffac8
+  languageName: node
+  linkType: hard
+
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -5662,6 +6030,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^9.14.2":
+  version: 9.15.1
+  resolution: "google-auth-library@npm:9.15.1"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^6.1.1"
+    gcp-metadata: "npm:^6.1.0"
+    gtoken: "npm:^7.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/6eef36d9a9cb7decd11e920ee892579261c6390104b3b24d3e0f3889096673189fe2ed0ee43fd563710e2560de98e63ad5aa4967b91e7f4e69074a422d5f7b65
+  languageName: node
+  linkType: hard
+
+"google-logging-utils@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "google-logging-utils@npm:0.0.2"
+  checksum: 10c0/9a4bbd470dd101c77405e450fffca8592d1d7114f245a121288d04a957aca08c9dea2dd1a871effe71e41540d1bb0494731a0b0f6fea4358e77f06645e4268c1
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -5680,6 +6069,16 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "gtoken@npm:7.1.0"
+  dependencies:
+    gaxios: "npm:^6.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/0a3dcacb1a3c4578abe1ee01c7d0bf20bffe8ded3ee73fc58885d53c00f6eb43b4e1372ff179f0da3ed5cfebd5b7c6ab8ae2776f1787e90d943691b4fe57c716
   languageName: node
   linkType: hard
 
@@ -5753,6 +6152,31 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
+  languageName: node
+  linkType: hard
+
+"html-to-text@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "html-to-text@npm:9.0.5"
+  dependencies:
+    "@selderee/plugin-htmlparser2": "npm:^0.11.0"
+    deepmerge: "npm:^4.3.1"
+    dom-serializer: "npm:^2.0.0"
+    htmlparser2: "npm:^8.0.2"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/5d2c77b798cf88a81b1da2fc1ea1a3b3e2ff49fe5a3d812392f802fff18ec315cf0969bd7846ef2eb7df8c37f463bc63e8cbdcf84e42696c6f3e15dfa61cdf4f
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "htmlparser2@npm:8.0.2"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.0.1"
+    entities: "npm:^4.4.0"
+  checksum: 10c0/609cca85886d0bf2c9a5db8c6926a89f3764596877492e2caa7a25a789af4065bc6ee2cdc81807fe6b1d03a87bf8a373b5a754528a4cc05146b713c20575aab4
   languageName: node
   linkType: hard
 
@@ -6072,6 +6496,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-network-error@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "is-network-error@npm:1.1.0"
+  checksum: 10c0/89eef83c2a4cf43d853145ce175d1cf43183b7a58d48c7a03e7eed4eb395d0934c1f6d101255cdd8c8c2980ab529bfbe5dd9edb24e1c3c28d2b3c814469b5b7d
+  languageName: node
+  linkType: hard
+
 "is-number@npm:^7.0.0":
   version: 7.0.0
   resolution: "is-number@npm:7.0.0"
@@ -6099,6 +6530,13 @@ __metadata:
   dependencies:
     isobject: "npm:^3.0.1"
   checksum: 10c0/f050fdd5203d9c81e8c4df1b3ff461c4bc64e8b5ca383bcdde46131361d0a678e80bcf00b5257646f6c636197629644d53bd8e2375aea633de09a82d57e942f4
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
   languageName: node
   linkType: hard
 
@@ -6316,6 +6754,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tiktoken@npm:^1.0.12":
+  version: 1.0.20
+  resolution: "js-tiktoken@npm:1.0.20"
+  dependencies:
+    base64-js: "npm:^1.5.1"
+  checksum: 10c0/846c9257b25efa153695bb2a4a85f35e2e747fa76f03d04dcaffee5b64ce22ccd61db83af099492558375eabf18c8070369d0f88de07a9fcf4cb494bb9759dbd
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -6366,6 +6813,15 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 10c0/531779df5ec94f47e462da26b4cbf05eb88a83d9f08aac2ba04206508fc598527a153d08bd462bae82fc78b3eaa1a908e1a4a79f886e9238641c4cdefaf118b1
+  languageName: node
+  linkType: hard
+
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: "npm:^9.0.0"
+  checksum: 10c0/e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
   languageName: node
   linkType: hard
 
@@ -6539,6 +6995,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwa@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
+  dependencies:
+    buffer-equal-constant-time: "npm:^1.0.1"
+    ecdsa-sig-formatter: "npm:1.0.11"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/ab3ebc6598e10dc11419d4ed675c9ca714a387481466b10e8a6f3f65d8d9c9237e2826f2505280a739cf4cbcf511cb288eeec22b5c9c63286fc5a2e4f97e78cf
+  languageName: node
+  linkType: hard
+
 "jws@npm:^3.2.2":
   version: 3.2.2
   resolution: "jws@npm:3.2.2"
@@ -6546,6 +7013,16 @@ __metadata:
     jwa: "npm:^1.4.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/e770704533d92df358adad7d1261fdecad4d7b66fa153ba80d047e03ca0f1f73007ce5ed3fbc04d2eba09ba6e7e6e645f351e08e5ab51614df1b0aa4f384dfff
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jws@npm:4.0.0"
+  dependencies:
+    jwa: "npm:^2.0.0"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/f1ca77ea5451e8dc5ee219cb7053b8a4f1254a79cb22417a2e1043c1eb8a569ae118c68f24d72a589e8a3dd1824697f47d6bd4fb4bebb93a3bdf53545e721661
   languageName: node
   linkType: hard
 
@@ -6580,6 +7057,13 @@ __metadata:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: 10c0/cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
+  languageName: node
+  linkType: hard
+
+"leac@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "leac@npm:0.6.0"
+  checksum: 10c0/5257781e10791ef8462eb1cbe5e48e3cda7692486f2a775265d6f5216cc088960c62f138163b8df0dcf2119d18673bfe7b050d6b41543d92a7b7ac90e4eb1e8b
   languageName: node
   linkType: hard
 
@@ -6636,6 +7120,35 @@ __metadata:
   dependencies:
     uc.micro: "npm:^2.0.0"
   checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
+  languageName: node
+  linkType: hard
+
+"llama-index-demo@workspace:apps/LlamaIndex-Demo":
+  version: 0.0.0-use.local
+  resolution: "llama-index-demo@workspace:apps/LlamaIndex-Demo"
+  dependencies:
+    "@agentmark/agentmark-core": "workspace:*"
+    "@agentmark/llamaindex-adapter": "workspace:^"
+    "@llamaindex/google": "npm:^0.3.18"
+    "@llamaindex/workflow": "npm:^1.1.20"
+    dotenv: "npm:^17.2.1"
+  languageName: unknown
+  linkType: soft
+
+"llamaindex@npm:^0.11.26":
+  version: 0.11.26
+  resolution: "llamaindex@npm:0.11.26"
+  dependencies:
+    "@llamaindex/cloud": "npm:4.1.1"
+    "@llamaindex/core": "npm:0.6.19"
+    "@llamaindex/env": "npm:0.1.30"
+    "@llamaindex/node-parser": "npm:2.0.19"
+    "@llamaindex/workflow": "npm:1.1.20"
+    "@types/lodash": "npm:^4.17.7"
+    "@types/node": "npm:^24.0.13"
+    lodash: "npm:^4.17.21"
+    magic-bytes.js: "npm:^1.10.0"
+  checksum: 10c0/6841950ae3f4247cc64f59cbe088aef43b54b5ff7c5cde595ef84f855b0dcebb8047b94389ab9b3d0f3ba10d69c446927cd488657953349a39f357a1f7e39ec7
   languageName: node
   linkType: hard
 
@@ -6837,6 +7350,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-bytes.js@npm:^1.10.0":
+  version: 1.12.1
+  resolution: "magic-bytes.js@npm:1.12.1"
+  checksum: 10c0/c99fc520d796d7b3f554728050252ee515707ffcd66b7db7dc4b0632863416e6a60b947ac4f97846267171d2856da7ab6dbfb2b910567e5b6cf9910fc1099de4
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.17":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
@@ -6852,6 +7372,13 @@ __metadata:
   dependencies:
     semver: "npm:^7.5.3"
   checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
+  languageName: node
+  linkType: hard
+
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
   languageName: node
   linkType: hard
 
@@ -7782,6 +8309,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 11.2.0
   resolution: "node-gyp@npm:11.2.0"
@@ -8057,6 +8598,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-retry@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "p-retry@npm:6.2.1"
+  dependencies:
+    "@types/retry": "npm:0.12.2"
+    is-network-error: "npm:^1.0.0"
+    retry: "npm:^0.13.1"
+  checksum: 10c0/10d014900107da2c7071ad60fffe4951675f09930b7a91681643ea224ae05649c05001d9e78436d902fe8b116d520dd1f60e72e091de097e2640979d56f3fb60
+  languageName: node
+  linkType: hard
+
 "p-timeout@npm:^5.0.2":
   version: 5.1.0
   resolution: "p-timeout@npm:5.1.0"
@@ -8168,6 +8720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseley@npm:^0.12.0":
+  version: 0.12.1
+  resolution: "parseley@npm:0.12.1"
+  dependencies:
+    leac: "npm:^0.6.0"
+    peberminta: "npm:^0.9.0"
+  checksum: 10c0/df3de74172b72305b867298a71e5882c413df75d30f2bafb5fb70779dfd349c5e4db03441fbf8ca83da8e4aa72bd0ef2b5c73086c4825d27d1c649d61bc0bcc0
+  languageName: node
+  linkType: hard
+
 "parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
@@ -8244,6 +8806,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
 "pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
@@ -8255,6 +8824,13 @@ __metadata:
   version: 2.0.0
   resolution: "pathval@npm:2.0.0"
   checksum: 10c0/602e4ee347fba8a599115af2ccd8179836a63c925c23e04bd056d0674a64b39e3a081b643cc7bc0b84390517df2d800a46fcc5598d42c155fe4977095c2f77c5
+  languageName: node
+  linkType: hard
+
+"peberminta@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "peberminta@npm:0.9.0"
+  checksum: 10c0/59c2c39269d9f7f559cf44582f1c0503524c6a9bc3478e0309adba2b41c71ab98745a239a4e6f98f46105291256e6d8f12ae9860d9f016b1c9a6f52c0b63bfe7
   languageName: node
   linkType: hard
 
@@ -8843,6 +9419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"retry@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 10c0/9ae822ee19db2163497e074ea919780b1efa00431d197c7afdb950e42bf109196774b92a49fc9821f0b8b328a98eea6017410bfc5e8a0fc19c85c6d11adb3772
+  languageName: node
+  linkType: hard
+
 "reusify@npm:^1.0.4":
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
@@ -9002,6 +9585,15 @@ __metadata:
   version: 2.7.0
   resolution: "secure-json-parse@npm:2.7.0"
   checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
+  languageName: node
+  linkType: hard
+
+"selderee@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "selderee@npm:0.11.0"
+  dependencies:
+    parseley: "npm:^0.12.0"
+  checksum: 10c0/c2ad8313a0dbf3c0b74752a8d03cfbc0931ae77a36679cdb64733eb732c1762f95a5174249bf7e8b8103874cb0e013a030f9c8b72f5d41e62f1d847d4a845d39
   languageName: node
   linkType: hard
 
@@ -9863,6 +10455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -9911,6 +10510,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.0.0":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:^0.8.0"
+    "@tsconfig/node10": "npm:^1.0.7"
+    "@tsconfig/node12": "npm:^1.0.7"
+    "@tsconfig/node14": "npm:^1.0.0"
+    "@tsconfig/node16": "npm:^1.0.2"
+    acorn: "npm:^8.4.1"
+    acorn-walk: "npm:^8.1.1"
+    arg: "npm:^4.1.0"
+    create-require: "npm:^1.1.0"
+    diff: "npm:^4.0.1"
+    make-error: "npm:^1.1.1"
+    v8-compile-cache-lib: "npm:^3.0.1"
+    yn: "npm:3.1.1"
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.2.0, tslib@npm:^2.6.2":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -9918,7 +10555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^8.3.5":
+"tsup@npm:^8.3.5, tsup@npm:^8.5.0":
   version: 8.5.0
   resolution: "tsup@npm:8.5.0"
   dependencies:
@@ -10115,6 +10752,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.0.0":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
@@ -10122,6 +10769,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.0.0#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
   languageName: node
   linkType: hard
 
@@ -10157,6 +10814,13 @@ __metadata:
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
   checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.10.0":
+  version: 7.10.0
+  resolution: "undici-types@npm:7.10.0"
+  checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
   languageName: node
   linkType: hard
 
@@ -10345,6 +11009,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 10c0/bdc36fb8095d3b41df197f5fb6f11e3a26adf4059df3213e3baa93810d8f0cc76f9a74aaefc18b73e91fe7e19154ed6f134eda6fded2e0f1c8d2272ed2d2d391
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.0":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -10527,6 +11207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^4.0.2":
   version: 4.0.2
   resolution: "webidl-conversions@npm:4.0.2"
@@ -10637,6 +11324,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
+  languageName: node
+  linkType: hard
+
 "whatwg-url@npm:^7.0.0":
   version: 7.1.0
   resolution: "whatwg-url@npm:7.1.0"
@@ -10729,6 +11426,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.0":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 
@@ -10854,6 +11566,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 10c0/0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
+  languageName: node
+  linkType: hard
+
 "yocto-queue@npm:^0.1.0":
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
@@ -10882,10 +11601,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.24.6":
+  version: 3.24.6
+  resolution: "zod-to-json-schema@npm:3.24.6"
+  peerDependencies:
+    zod: ^3.24.1
+  checksum: 10c0/b907ab6d057100bd25a37e5545bf5f0efa5902cd84d3c3ec05c2e51541431a47bd9bf1e5e151a244273409b45f5986d55b26e5d207f98abc5200702f733eb368
+  languageName: node
+  linkType: hard
+
 "zod@npm:^3.23.8":
   version: 3.25.23
   resolution: "zod@npm:3.25.23"
   checksum: 10c0/c0a9d1b215ead64fdd1f3be47bc7376be6016472ae5bd1ef56d0a579d544b785b5e266dbd30947172e5b92873b7a8bed123625eeb00aea4e5d7526d86a5a31f6
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. **AgentMark ↔ LlamaIndex Bridge:**

   * Implements a class `LlamaIndexAdapter` that conforms to AgentMark’s `Adapter<TextPrompt>` interface.
   * Acts as a translator between AgentMark’s standardized prompt format and the internal mechanics of LlamaIndex agents.

2. **Query Execution via LlamaIndex (Demo) :**

   * Constructs LlamaIndex Agents and run queries based on the AgentMark Syntax in Demo.

3. **Seamless Integration:**

   * Exports the adapter in a structure recognizable by AgentMark so it can be used as a plug-in during prompt execution workflows.
