### PR TITLE
Enhance UI components with empty content image support

### DIFF
--- a/packages/cli/cli-src/api-server.ts
+++ b/packages/cli/cli-src/api-server.ts
@@ -543,3 +543,4 @@ ${promptsList}
   });
 }
 
+

--- a/packages/ui-components/src/components/datagrid/datagrid.tsx
+++ b/packages/ui-components/src/components/datagrid/datagrid.tsx
@@ -10,12 +10,17 @@ import { EmptyContent } from "@/components";
 
 type CustomDataGridProps = DataGridProps & {
   t: any;
+  emptyContentImgUrl?: string;
 };
 
-export const DataGrid = ({ t, ...props }: CustomDataGridProps) => {
+export const DataGrid = ({
+  t,
+  emptyContentImgUrl,
+  ...props
+}: CustomDataGridProps) => {
   return (
     <MuiDataGrid
-      sx={{ '--DataGrid-overlayHeight': '530px' }}
+      sx={{ "--DataGrid-overlayHeight": "530px" }}
       {...props}
       slots={{
         toolbar: () => {
@@ -35,10 +40,18 @@ export const DataGrid = ({ t, ...props }: CustomDataGridProps) => {
           );
         },
         noRowsOverlay: () => (
-          <EmptyContent sx={{ margin: 2 }} title={t("noResults")} />
+          <EmptyContent
+            sx={{ margin: 2 }}
+            title={t("noResults")}
+            imgUrl={emptyContentImgUrl}
+          />
         ),
         noResultsOverlay: () => (
-          <EmptyContent title={t("noResults")} sx={{ py: 10 }} />
+          <EmptyContent
+            title={t("noResults")}
+            sx={{ py: 10 }}
+            imgUrl={emptyContentImgUrl}
+          />
         ),
       }}
       slotProps={{

--- a/packages/ui-components/src/components/empty-content/empty-content.tsx
+++ b/packages/ui-components/src/components/empty-content/empty-content.tsx
@@ -2,6 +2,7 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Stack, { StackProps } from "@mui/material/Stack";
 import { Iconify } from "../iconify";
+import { Box } from "@mui/material";
 
 type EmptyContentProps = StackProps & {
   title?: string;
@@ -38,7 +39,20 @@ export default function EmptyContent({
       }}
       {...other}
     >
-      <Iconify sx={{ color: "text.disabled" }} icon="fluent:collections-empty-20-filled" width={250} />
+      {imgUrl ? (
+        <Box
+          component="img"
+          alt="empty content"
+          src={imgUrl || "/assets/icons/empty/ic_content.svg"}
+          sx={{ width: 1, maxWidth: 160 }}
+        />
+      ) : (
+        <Iconify
+          sx={{ color: "text.disabled" }}
+          icon="fluent:collections-empty-20-filled"
+          width={160}
+        />
+      )}
 
       {title && (
         <Typography

--- a/packages/ui-components/src/components/table/table-no-data.tsx
+++ b/packages/ui-components/src/components/table/table-no-data.tsx
@@ -8,9 +8,10 @@ type Props = {
   notFound: boolean;
   sx?: SxProps<Theme>;
   title: string;
+  imgUrl?: string;
 };
 
-export default function TableNoData({ title, notFound, sx }: Props) {
+export default function TableNoData({ title, notFound, sx, imgUrl }: Props) {
   return (
     <TableRow>
       {notFound ? (
@@ -22,6 +23,7 @@ export default function TableNoData({ title, notFound, sx }: Props) {
               py: 10,
               ...sx,
             }}
+            imgUrl={imgUrl}
           />
         </TableCell>
       ) : (

--- a/packages/ui-components/src/sections/requests/request-table.tsx
+++ b/packages/ui-components/src/sections/requests/request-table.tsx
@@ -26,6 +26,7 @@ export type RequestTableProps = {
   paginationMode?: "server" | "client";
   sortingMode?: "server" | "client";
   t: any;
+  emptyContentImgUrl?: string;
 };
 
 export const RequestTable = ({
@@ -43,6 +44,7 @@ export const RequestTable = ({
   paginationMode,
   sortingMode,
   t,
+  emptyContentImgUrl,
 }: RequestTableProps) => {
   const tableData = useMemo(() => {
     if (requests) {
@@ -189,6 +191,7 @@ export const RequestTable = ({
   return (
     <DataGrid
       t={t}
+      emptyContentImgUrl={emptyContentImgUrl}
       onRowClick={(params) => onRowClick?.(params.row)}
       rows={tableData}
       loading={loading}

--- a/packages/ui-components/src/sections/sessions/sessions-list.tsx
+++ b/packages/ui-components/src/sections/sessions/sessions-list.tsx
@@ -32,6 +32,7 @@ export interface SessionsListProps {
   table: TableProps;
   onSessionClick: (session: SessionData) => void;
   t: (key: string) => string;
+  emptyContentImgUrl?: string;
 }
 
 export const SessionsList = ({
@@ -41,6 +42,7 @@ export const SessionsList = ({
   table,
   onSessionClick,
   t,
+  emptyContentImgUrl,
 }: SessionsListProps) => {
   return (
     <TableContainer>
@@ -91,6 +93,7 @@ export const SessionsList = ({
             title={t("noSessions")}
             sx={{ p: 3 }}
             notFound={!isLoading && sessions.length === 0}
+            imgUrl={emptyContentImgUrl}
           />
         </TableBody>
       </Table>

--- a/packages/ui-components/src/sections/traces/trace-drawer/span-info/hooks/use-span-info.ts
+++ b/packages/ui-components/src/sections/traces/trace-drawer/span-info/hooks/use-span-info.ts
@@ -40,7 +40,7 @@ export const useSpanInfo = ({ span }: UseSpanInfoProps) => {
         });
         setActiveTab("inputOutput");
       } else {
-        setActiveTab("attributes");
+        setActiveTab("evaluation");
       }
       newTabs.push({
         value: "evaluation",

--- a/packages/ui-components/src/sections/traces/trace-drawer/span-info/tabs/evaluation-tab/evaluation-list.tsx
+++ b/packages/ui-components/src/sections/traces/trace-drawer/span-info/tabs/evaluation-tab/evaluation-list.tsx
@@ -13,13 +13,19 @@ import { ScoreData } from "@/sections/traces/types";
 import { EmptyContent } from "@/components";
 import { EvaluationItem } from "./evaluation-item";
 import { useEvaluationContext } from "./evaluation-provider";
+import { EvaluationSkeleton } from "./evaluation-skeleton";
+import TableNoData from "@/components/table/table-no-data";
 
-export const EvaluationList = () => {
+export const EvaluationList = ({
+  emptyContentImgUrl,
+}: {
+  emptyContentImgUrl?: string;
+}) => {
   const { scores, isLoading } = useEvaluationContext();
   const { t } = useTraceDrawerContext();
 
-  if (!isLoading && scores.length === 0) {
-    return <EmptyContent title={t("noEvaluationData")} />;
+  if (isLoading) {
+    return <EvaluationSkeleton />;
   }
 
   return (
@@ -46,6 +52,12 @@ export const EvaluationList = () => {
                 source={scoreData.source}
               />
             ))}
+            <TableNoData
+              title={t("noEvaluationData")}
+              sx={{ p: 3 }}
+              notFound={!isLoading && scores.length === 0}
+              imgUrl={emptyContentImgUrl}
+            />
           </TableBody>
         </Table>
       </TableContainer>

--- a/packages/ui-components/src/sections/traces/trace-list/trace-list-item.tsx
+++ b/packages/ui-components/src/sections/traces/trace-list/trace-list-item.tsx
@@ -43,7 +43,7 @@ const TraceListItem = ({ trace, onClick }: TraceListItemProps) => {
           {(parseInt(trace.latency) / 1000).toFixed(2)}s
         </Label>
       </TableCell>
-      <TableCell>{fCurrency(trace.cost, 5)}</TableCell>
+      <TableCell>{fCurrency(`${trace.cost}` || 0, 5)}</TableCell>
       <TableCell>
         <Label color="default" startIcon={<Iconify icon="game-icons:token" />}>
           {fNumber(trace.tokens || 0)}

--- a/packages/ui-components/src/sections/traces/trace-list/trace-list.tsx
+++ b/packages/ui-components/src/sections/traces/trace-list/trace-list.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  Table,
-  TableBody,
-  TableContainer,
-} from "@mui/material";
+import { Table, TableBody, TableContainer } from "@mui/material";
 import {
   TableHeadCustom,
   TablePaginationCustom,
@@ -22,6 +18,8 @@ export interface TracesListProps {
   table: TableProps;
   onTraceClick: (trace: Trace) => void;
   t: (key: string) => string;
+  emptyContentImgUrl?: string;
+  emptyContentText?: string;
 }
 
 export const TracesList = ({
@@ -31,6 +29,8 @@ export const TracesList = ({
   table,
   onTraceClick,
   t,
+  emptyContentImgUrl,
+  emptyContentText,
 }: TracesListProps) => {
   return (
     <TableContainer>
@@ -55,9 +55,10 @@ export const TracesList = ({
           ))}
           {isLoading && <TableSkeleton />}
           <TableNoData
-            title={t("noTraces")}
+            title={emptyContentText || t("noTraces")}
             sx={{ p: 3 }}
             notFound={!isLoading && traces.length === 0}
+            imgUrl={emptyContentImgUrl}
           />
         </TableBody>
       </Table>
@@ -74,4 +75,3 @@ export const TracesList = ({
     </TableContainer>
   );
 };
-


### PR DESCRIPTION
- Added `emptyContentImgUrl` prop to `DataGrid`, `TableNoData`, and `EmptyContent` components for customizable empty state images.
- Updated `EvaluationList` and `SessionsList` to utilize the new prop, improving user experience when no data is available.
- Refactored `TracesList` to allow for customizable empty content text and image, enhancing flexibility in displaying empty states.

These changes improve the visual feedback provided to users when data is not present, making the UI more informative and engaging.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
