### PR TITLE
Refactor trace handling in adapters to improve result extraction

### DIFF
--- a/packages/ai-sdk-v5-adapter/src/runner.ts
+++ b/packages/ai-sdk-v5-adapter/src/runner.ts
@@ -56,9 +56,10 @@ export class VercelAdapterWebhookHandler {
       const shouldStream =
         options?.shouldStream !== undefined ? options.shouldStream : true;
       if (shouldStream) {
-        const { result: { usage, fullStream }, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+        const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
           return streamObject(input);
         });
+        const { usage, fullStream } = await result;
         const stream = new ReadableStream({
           async start(controller) {
             const encoder = new TextEncoder();
@@ -108,9 +109,10 @@ export class VercelAdapterWebhookHandler {
           traceId,
         } as WebhookPromptResponse;
       }
-      const { result: { object, usage, finishReason }, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return generateObject(input);
       });
+      const { object, usage, finishReason } = await result;
       return {
         type: "object",
         result: object,
@@ -132,9 +134,10 @@ export class VercelAdapterWebhookHandler {
       const shouldStream =
         options?.shouldStream !== undefined ? options.shouldStream : true;
       if (shouldStream) {
-        const { result: { fullStream }, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+        const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
           return streamText(input);
         });
+        const { fullStream } = await result;
         const stream = new ReadableStream({
           async start(controller) {
             const encoder = new TextEncoder();
@@ -215,9 +218,10 @@ export class VercelAdapterWebhookHandler {
           traceId,
         } as WebhookPromptResponse;
       }
-      const { result: { text, usage, finishReason, steps }, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return generateText(input);
       });
+      const { text, usage, finishReason, steps } = await result;
       const toolCalls = steps?.flatMap((s: any) => s.toolCalls) ?? [];
       const toolResults = steps?.flatMap((s: any) => s.toolResults) ?? [];
       return {
@@ -240,9 +244,10 @@ export class VercelAdapterWebhookHandler {
       const input = options?.customProps
         ? await prompt.format({ props: options.customProps, telemetry })
         : await prompt.formatWithTestProps({ telemetry });
-      const { result: imageResult, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return generateImage(input);
       });
+      const imageResult = await result;
       return {
         type: "image",
         result: imageResult.images.map((i: any) => ({
@@ -258,9 +263,10 @@ export class VercelAdapterWebhookHandler {
       const input = options?.customProps
         ? await prompt.format({ props: options.customProps, telemetry })
         : await prompt.formatWithTestProps({ telemetry });
-      const { result: speechResult, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return generateSpeech(input);
       });
+      const speechResult = await result;
       return {
         type: "speech",
         result: {
@@ -305,7 +311,7 @@ export class VercelAdapterWebhookHandler {
             if (done) break;
             if (item.type === "error") continue;
             const formatted = item.formatted as any;
-            const { result: { text, usage }, traceId } = await trace({
+            const { result, traceId } = await trace({
               name: `experiment-${datasetRunName}-${index}`,
               datasetRunId: experimentRunId,
               datasetRunName: datasetRunName,
@@ -322,6 +328,7 @@ export class VercelAdapterWebhookHandler {
                 },
               });
             });
+            const { text, usage } = await result;
 
             let evalResults: any[] = [];
             if (
@@ -388,7 +395,7 @@ export class VercelAdapterWebhookHandler {
             const { value: item, done } = await reader.read();
             if (done) break;
             if (item.type === "error") continue;
-            const { result: { object, usage }, traceId } = await trace({
+            const { result, traceId } = await trace({
               name: `experiment-${datasetRunName}-${index}`,
               datasetRunId: experimentRunId,
               datasetRunName: datasetRunName,
@@ -405,6 +412,7 @@ export class VercelAdapterWebhookHandler {
                 },
               });
             });
+            const { object, usage } = await result;
 
             let evalResults: any[] = [];
             if (

--- a/packages/mastra-v0-adapter/src/runner.ts
+++ b/packages/mastra-v0-adapter/src/runner.ts
@@ -53,9 +53,10 @@ export class MastraAdapterWebhookHandler {
 
       if (shouldStream) {
         try {
-          const { result: streamResult, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+          const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
             return agent.stream(messages, generateOptions);
           });
+          const streamResult = await result;
           const fullStream = (streamResult as any).fullStream;
           
           if (fullStream) {
@@ -134,9 +135,10 @@ export class MastraAdapterWebhookHandler {
       }
 
       // Non-streaming object generation
-      const { result: response, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return agent.generate(messages, generateOptions);
       });
+      const response = await result;
       return {
         type: "object",
         result: (response as any).object || response,
@@ -161,9 +163,10 @@ export class MastraAdapterWebhookHandler {
 
       if (shouldStream) {
         try {
-          const { result: streamResult, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+          const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
             return agent.stream(messages, generateOptions);
           });
+          const streamResult = await result;
           const fullStream = (streamResult as any).fullStream;
           
           if (fullStream) {
@@ -262,9 +265,10 @@ export class MastraAdapterWebhookHandler {
       }
 
       // Non-streaming text generation
-      const { result: response, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
+      const { result, traceId } = await trace({ name: frontmatter.name || 'prompt-run' }, async (_ctx) => {
         return agent.generate(messages, generateOptions);
       });
+      const response = await result;
       return {
         type: "text",
         result:
@@ -326,7 +330,7 @@ export class MastraAdapterWebhookHandler {
                 ...(options.telemetry?.metadata ?? {}),
               };
 
-              const { result: response, traceId } = await trace({
+              const { result, traceId } = await trace({
                 name: `ds-run-${datasetRunName}-${index}`,
                 datasetRunId: runId,
                 datasetRunName: datasetRunName,
@@ -344,6 +348,7 @@ export class MastraAdapterWebhookHandler {
                 });
               });
 
+              const response = await result;
               const text =
                 (response as any).text ||
                 (response as any).content ||
@@ -431,7 +436,7 @@ export class MastraAdapterWebhookHandler {
                 ...(options.telemetry?.metadata ?? {}),
               };
 
-              const { result: response, traceId } = await trace({
+              const { result, traceId } = await trace({
                 name: `ds-run-${datasetRunName}-${index}`,
                 datasetRunId: runId,
                 datasetRunName: datasetRunName,
@@ -449,6 +454,7 @@ export class MastraAdapterWebhookHandler {
                 });
               });
 
+              const response = await result;
               const object = (response as any).object || response;
               const usage = (response as any).usage;
 

--- a/packages/sdk/src/test/tracing.test.ts
+++ b/packages/sdk/src/test/tracing.test.ts
@@ -145,7 +145,7 @@ describe("OTLP Exporter", () => {
     const { result: result1, traceId: traceId1 } = await trace({ name: "test-span" }, async (_ctx) => {
       return "test";
     });
-    expect(result1).toBe("test");
+    expect(await result1).toBe("test");
     expect(traceId1).toBeTruthy();
     await flushSpans();
 
@@ -560,7 +560,7 @@ describe("OTLP Exporter", () => {
     });
     await flushSpans();
 
-    expect(caughtResult).toBe("parent-success");
+    expect(await caughtResult).toBe("parent-success");
 
     // Verify parent span has OK status
     const catchParent = findSpanByName("catch-parent");


### PR DESCRIPTION
- Updated the result extraction logic in the VercelAdapterWebhookHandler for ai-sdk-v4, ai-sdk-v5, and mastra-v0 adapters to directly await the result from the trace function, enhancing clarity and consistency across implementations.
- Adjusted related code to ensure proper handling of streaming and non-streaming responses, improving overall data processing and response structure.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
