### PR TITLE
fix: release workflow checkout failure and plan check false positives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,9 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.check-pr.outputs.branch_name }}"
 
-          # Clean up untracked files that may conflict with checkout
+          # Clean up untracked and modified files that may conflict with checkout
           rm -f audit-output.txt
+          git checkout -- .
 
           # Fetch and checkout the existing branch
           git fetch origin $BRANCH_NAME

--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,10 @@
         "**/*.test.tsx",
         "**/test/**",
         "**/tests/**",
-        "**/__tests__/**"
+        "**/__tests__/**",
+        ".github/**",
+        "yarn.lock",
+        "package.json"
       ]
     },
     "projects": ["packages/*"],


### PR DESCRIPTION
## Summary
- **Release workflow fix**: `yarn install --immutable` dirties `package.json`, causing `git checkout release/version-plans` to fail with "local changes would be overwritten". Added `git checkout -- .` before switching branches to reset the working tree.
- **Plan check fix**: Added `.github/**`, `yarn.lock`, and root `package.json` to `ignorePatternsForPlanCheck` in `nx.json` so infra-only changes don't falsely require version plans.

## Test plan
- [ ] Release workflow `prepare` job passes on push to main
- [ ] `yarn release:plan:check` passes for PRs with only infra file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)