### PR TITLE
chore: restore version plans lost during sync

### DIFF
--- a/.nx/version-plans/025-seamless-pull-models.md
+++ b/.nx/version-plans/025-seamless-pull-models.md
@@ -1,0 +1,16 @@
+---
+'@agentmark-ai/cli': minor
+'@agentmark-ai/prompt-core': minor
+'@agentmark-ai/ai-sdk-v4-adapter': minor
+'@agentmark-ai/ai-sdk-v5-adapter': minor
+'@agentmark-ai/claude-agent-sdk-adapter': minor
+'@agentmark-ai/mastra-v0-adapter': minor
+'create-agentmark': minor
+---
+
+Add seamless pull-models flow with provider/model format
+
+- prompt-core: validate model names against builtInModels allow-list at load time
+- ai-sdk-v4-adapter, ai-sdk-v5-adapter: add registerProviders() and getModelFunction() for seamless provider/model string resolution; add speech model support
+- claude-agent-sdk-adapter, mastra-v0-adapter: update model registry to use provider/model format
+- create-agentmark: scaffold new projects with builtInModels in provider/model format and registerProviders wiring

--- a/.nx/version-plans/feat-remote-trace-link.md
+++ b/.nx/version-plans/feat-remote-trace-link.md
@@ -1,0 +1,13 @@
+---
+'@agentmark-ai/cli': minor
+---
+
+Show remote trace URL when running `agentmark dev --remote`
+
+When trace forwarding is active, `agentmark run` now prints both the local
+and remote trace URLs after each prompt execution, along with a warning that
+remote traces may take up to 1 minute to appear.
+
+- Add `org_name` to `DevKeyResponse` interface (returned by the updated platform API)
+- Add `orgName` to `ForwardingConfig` so the remote URL can be constructed from the persisted config
+- `run-prompt` conditionally shows the remote URL when forwarding is active; falls back to the plain local URL for unlinked sessions

--- a/.nx/version-plans/fix-builtin-models-from-templates.md
+++ b/.nx/version-plans/fix-builtin-models-from-templates.md
@@ -1,0 +1,9 @@
+---
+'create-agentmark': patch
+---
+
+Fix builtInModels derived from templates instead of hardcoded adapter switch
+
+- createExamplePrompts() now returns the model IDs it actually writes, making it the single source of truth for builtInModels
+- Removes the hardcoded adapter→model switch that was missing openai/dall-e-3 and openai/tts-1-hd for ai-sdk users
+- ai-sdk users now get all three models (gpt-4o, dall-e-3, tts-1-hd) in builtInModels on init

--- a/.nx/version-plans/fix-create-agentmark-init-fixes.md
+++ b/.nx/version-plans/fix-create-agentmark-init-fixes.md
@@ -1,0 +1,9 @@
+---
+'create-agentmark': patch
+'@agentmark-ai/cli': patch
+---
+
+Fix agentmark.json missing from initial git commit and duplicate dev-config.json locations
+
+- create-agentmark: move initGitRepo() to main() so it runs after agentmark.json is written, ensuring all files land in the initial commit
+- cli: add findProjectRoot() that walks up to find agentmark.json, anchoring .agentmark/dev-config.json there as a single source of truth regardless of which directory agentmark dev is run from

--- a/.nx/version-plans/fix-pull-models-ux.md
+++ b/.nx/version-plans/fix-pull-models-ux.md
@@ -1,0 +1,9 @@
+---
+'@agentmark-ai/cli': patch
+---
+
+Fix pull-models UX: require at least one model selection, show accurate success message, and remove prompt.schema.json auto-generation
+
+- Add `min: 1` to the models multiselect so users can't accidentally confirm with zero selections
+- Replace generic "Models pulled successfully." with "Added N model(s): ..." to accurately reflect what changed
+- Remove automatic `prompt.schema.json` regeneration from `pull-models` (schema generation was not reliably useful without additional IDE setup)


### PR DESCRIPTION
## Summary
The sync workflow's cleanup step (PR #1569 on the monorepo) triggered a re-sync that overwrote `sync/upstream` without version plans. This restores the 5 version plan files so the Prepare Release workflow can process the pending releases.

## Version Plans Restored
- `025-seamless-pull-models.md` — minor bumps for cli, prompt-core, adapters, create-agentmark
- `feat-remote-trace-link.md` — minor bump for cli
- `fix-builtin-models-from-templates.md` — patch for create-agentmark
- `fix-create-agentmark-init-fixes.md` — patch for create-agentmark + cli
- `fix-pull-models-ux.md` — patch for cli

## Root Cause
Version plan cleanup from the monorepo (`oss/agentmark/.nx/version-plans/` deletion) triggered the OSS sync workflow, which force-pushed `sync/upstream` without the plans. The pending sync PR (#498) then merged without them, so Prepare Release found nothing to release.