### PR TITLE
chore: add version plan for create-agentmark

### DIFF
--- a/.nx/version-plans/create-agentmark-template-updates.md
+++ b/.nx/version-plans/create-agentmark-template-updates.md
@@ -1,0 +1,5 @@
+---
+'create-agentmark': patch
+---
+
+Update example templates: simplify tool definitions to string array format, fix ast type from unknown to any.


### PR DESCRIPTION
## Summary
- Adds missing nx version plan (patch) for `create-agentmark` template changes from PR #525
- Changes: simplified tool definitions to string array format, fixed `ast` type from `unknown` to `any`

🤖 Generated with [Claude Code](https://claude.com/claude-code)