### PR TITLE
ci: add uv for Python dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: 21
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
         run: yarn install
 
@@ -71,6 +74,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install
         run: yarn install

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: 21
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: 21
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

Adds `astral-sh/setup-uv@v5` to all CI/release workflows that run `yarn install`, which triggers Python package postinstall scripts.

## Why

The `setup-python-venv.js` script (used by all Python packages' postinstall) now prefers `uv pip install` over `pip install`. `uv` correctly resolves editable installs alongside PyPI deps — pip's resolver hits `resolution-too-deep` when a local editable package (e.g., `agentmark-sdk` from `../sdk-python`) has different dependencies than its published PyPI version.

Without `uv` available, the script falls back to `pip` which may fail for packages that declare `agentmark-sdk>=0.0.1` as a dep while also doing `-e ../sdk-python` in the postinstall.

## Changes

Added `astral-sh/setup-uv@v5` step before `yarn install` in:
- `ci.yml` — `security-audit` job + `build` job (runs on ubuntu + windows)
- `release.yml` — `prepare-release` job
- `release-publish.yml` — `publish` job

`setup-uv` supports all platforms (Linux, macOS, Windows).

## Related

- agentmark-ai/app#1875 — the PR that replaced the protobuf OTLP exporter with JSON, causing the PyPI vs local dep mismatch that triggers pip's resolution failure