### PR TITLE
revert: remove setup-uv from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           node-version: 21
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
       - name: Install dependencies
         run: yarn install
 
@@ -74,9 +71,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
 
       - name: Install
         run: yarn install

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,9 +30,6 @@ jobs:
           node-version: 21
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
           node-version: 21
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
Reverts #568.

No longer needed — `setup-python-venv.js` now installs `uv` into the venv itself via `pip install uv`. This makes uv self-provisioning; no external tool setup required in any workflow.

The script checks `.venv/bin/uv`, and if missing, runs `pip install uv` into the venv (~2s). All workflows that trigger Python postinstalls via `yarn install` get uv automatically.