### PR TITLE
fix(sdk-python): set User-Agent on OTLP exports to bypass Cloudflare BIC

### DIFF
--- a/.nx/version-plans/fix-sdk-python-cloudflare-bic-ua.md
+++ b/.nx/version-plans/fix-sdk-python-cloudflare-bic-ua.md
@@ -1,0 +1,20 @@
+---
+"agentmark-sdk": patch
+---
+
+fix: set explicit User-Agent on OTLP span exports to bypass Cloudflare BIC
+
+Cloudflare's Browser Integrity Check rejects requests bearing the default
+`Python-urllib/*` User-Agent with HTTP 403 (error code 1010). `JsonOtlpSpanExporter`
+uses `urllib.request.urlopen` without setting a UA, so every trace export through
+a Cloudflare-proxied zone (api.agentmark.co, api-stg.agentmark.co) was silently
+rejected before reaching the gateway. Combined with the exporter's bare
+`except Exception: return FAILURE`, the failure produced no logs, no metrics,
+and no ClickHouse rows — just a complete absence of traces.
+
+The `ApiLoader` path (`/v1/templates` etc.) wasn't affected because it uses
+`httpx`, whose default UA `python-httpx/<version>` isn't on the BIC block list.
+
+Set `User-Agent: agentmark-sdk-python/<version>` on every outbound POST. The
+version is resolved at import time via `importlib.metadata.version("agentmark-sdk")`
+so it stays in lockstep with the installed distribution.

--- a/packages/sdk-python/src/agentmark_sdk/otlp_json_exporter.py
+++ b/packages/sdk-python/src/agentmark_sdk/otlp_json_exporter.py
@@ -15,11 +15,18 @@ import base64
 import json
 import urllib.request
 from collections import defaultdict
+from importlib.metadata import version as _pkg_version
 from typing import Any, Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import SpanKind
+
+# Cloudflare Browser Integrity Check rejects the default urllib User-Agent
+# ("Python-urllib/x.y") with a 403 error code 1010. Set an explicit SDK UA so
+# requests through proxied zones (api.agentmark.co et al) aren't blocked
+# before reaching the gateway.
+_SDK_USER_AGENT = f"agentmark-sdk-python/{_pkg_version('agentmark-sdk')}"
 
 # OTLP wire format uses 1-indexed SpanKind values (UNSPECIFIED=0,
 # INTERNAL=1, SERVER=2, ...) while the Python API uses 0-indexed
@@ -50,6 +57,7 @@ class JsonOtlpSpanExporter(SpanExporter):
             data=payload,
             headers={
                 "Content-Type": "application/json",
+                "User-Agent": _SDK_USER_AGENT,
                 **self._headers,
             },
             method="POST",


### PR DESCRIPTION
## Summary

- Cloudflare's Browser Integrity Check rejects the default `Python-urllib/*` User-Agent with a 403 (error code 1010), silently dropping every OTLP span export through proxied zones (api.agentmark.co, api-stg.agentmark.co).
- `JsonOtlpSpanExporter` now sets `User-Agent: agentmark-sdk-python/<version>` on every POST; version resolved via `importlib.metadata.version("agentmark-sdk")`.
- Includes nx version-plan for a patch bump. Extracted from #583 to ship independently.

## Why this was silent

`JsonOtlpSpanExporter` catches every exception in `export()` and returns `SpanExportResult.FAILURE` without logging. The `ApiLoader` path (`/v1/templates`, datasets, etc.) uses `httpx` — whose default UA is not on the BIC block list — which is why templates worked but traces didn't.

## Test plan

- [x] Verified end-to-end against `api-stg.agentmark.co`: patched SDK → CF edge → staging gateway → queue → ClickHouse, with canary spans and a real pydantic-ai experiment run (invoke_agent span, 1315 tokens, \$0.00185, visible in staging dashboard Traces tab).
- [ ] CI build + tests pass.